### PR TITLE
hal: remove __SPLIT__ macros and add HAL update README 

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,21 @@
+General Notes for Cadence/Tensillica HAL Updates
+================================================
+
+The xtensa HAL is supplied by Cadence/Tensillica and is indended to support all
+xtensa ISA configurations used by different devices.
+
+Zephyr needs certain HAL modifications for ease of management for use within
+Zephyr and these changes need to be applied to any HAL updates from Cadence.
+
+1) Remove usage of __SPLIT__ from HAL build.
+--------------------------------------------
+
+The HAL build script creates individual source files per functions by defining
+__SPLIT_* macros and including corresponding source files, in an attempt to
+compile one function per file. These should be removed. See
+84ff6039fc8f435551bb7915e098184c95fa24f2 and
+16324fd861596f57517524cd9d6fc66b077db4e8.
+
+
+This file should be updated accordingly to reflect any new changes required
+in new HALs.

--- a/src/hal/cache_asm.S
+++ b/src/hal/cache_asm.S
@@ -180,8 +180,6 @@ xthal_icache_hugerange_\name:
 // Read CACHEATTR register
 //----------------------------------------------------------------------
 
-#if defined(__SPLIT__get_cacheattr) ||\
-    defined(__SPLIT__get_cacheattr_nw)
 
 //  unsigned xthal_get_cacheattr(void);
 
@@ -195,10 +193,7 @@ DECLFUNC(xthal_get_icacheattr)
 	abi_return
 	endfunc
 
-#endif
 
-#if defined(__SPLIT__get_icacheattr) ||\
-    defined(__SPLIT__get_icacheattr_nw)
 
 //  unsigned xthal_get_icacheattr(void);
 
@@ -210,7 +205,6 @@ DECLFUNC(xthal_get_icacheattr)
 	endfunc
 # endif
 
-#endif /*split*/
 
 
 //----------------------------------------------------------------------
@@ -225,8 +219,6 @@ DECLFUNC(xthal_get_icacheattr)
  *	void  xthal_set_dcacheattr( unsigned new_cacheattr );
  */
 
-#if defined(__SPLIT__set_cacheattr) ||\
-	defined(__SPLIT__set_cacheattr_nw)
 
 # if XCHAL_HAVE_CACHEATTR	/* single CACHEATTR register used for both I and D accesses */
 DECLFUNC(xthal_set_icacheattr)
@@ -238,7 +230,6 @@ DECLFUNC(xthal_set_cacheattr)
 	abi_return
 	endfunc
 
-#endif /*split*/
 
 
 #if XCHAL_HAVE_CACHEATTR
@@ -255,8 +246,6 @@ DECLFUNC(xthal_set_cacheattr)
 
 #elif XCHAL_HAVE_MIMIC_CACHEATTR || XCHAL_HAVE_XLT_CACHEATTR || (XCHAL_HAVE_PTP_MMU && XCHAL_HAVE_SPANNING_WAY)
 
-# if defined(__SPLIT__set_icacheattr) \
-	 || defined(__SPLIT__set_icacheattr_nw)
 
 DECLFUNC(xthal_set_icacheattr)
 	abi_entry
@@ -265,10 +254,7 @@ DECLFUNC(xthal_set_icacheattr)
 	abi_return
 	endfunc
 
-# endif
 
-# if defined(__SPLIT__set_dcacheattr) \
-	 || defined(__SPLIT__set_dcacheattr_nw)
 
 DECLFUNC(xthal_set_dcacheattr)
 	abi_entry
@@ -276,12 +262,9 @@ DECLFUNC(xthal_set_dcacheattr)
 	abi_return
 	endfunc
 
-# endif /*split*/
 
 #else /* full MMU (pre-v3): */
 
-# if defined(__SPLIT__set_idcacheattr) \
-	 || defined(__SPLIT__set_idcacheattr_nw)
 
 //  These functions aren't applicable to arbitrary MMU configurations.
 //  Do nothing in this case.
@@ -292,7 +275,6 @@ DECLFUNC(xthal_set_dcacheattr)
 	abi_return
 	endfunc
 
-# endif /*split*/
 
 #endif /* cacheattr/MMU type */
 
@@ -309,8 +291,6 @@ DECLFUNC(xthal_set_dcacheattr)
 
 #if XCHAL_HAVE_CACHEATTR
 
-# if defined(__SPLIT__idcache_is_enabled) || \
-     defined(__SPLIT__idcache_is_enabled_nw)
 
 DECLFUNC(xthal_icache_is_enabled)
 DECLFUNC(xthal_dcache_is_enabled)
@@ -322,12 +302,9 @@ DECLFUNC(xthal_dcache_is_enabled)
 	abi_return
 	endfunc
 
-# endif /*split*/
 
 #elif XCHAL_HAVE_MIMIC_CACHEATTR || XCHAL_HAVE_XLT_CACHEATTR
 
-# if defined(__SPLIT__icache_is_enabled) || \
-     defined(__SPLIT__icache_is_enabled_nw)
 
 DECLFUNC(xthal_icache_is_enabled)
 	abi_entry
@@ -338,10 +315,7 @@ DECLFUNC(xthal_icache_is_enabled)
 	abi_return
 	endfunc
 
-# endif
 
-# if defined(__SPLIT__dcache_is_enabled) || \
-     defined(__SPLIT__dcache_is_enabled_nw)
 
 DECLFUNC(xthal_dcache_is_enabled)
 	abi_entry
@@ -352,15 +326,12 @@ DECLFUNC(xthal_dcache_is_enabled)
 	abi_return
 	endfunc
 
-# endif /*split*/
 
 #else
 
 //  These functions aren't applicable to arbitrary MMU configurations.
 //  Assume caches are enabled in this case (!).
 
-# if defined(__SPLIT__idcache_is_enabled) || \
-     defined(__SPLIT__idcache_is_enabled_nw)
 
 DECLFUNC(xthal_icache_is_enabled)
 DECLFUNC(xthal_dcache_is_enabled)
@@ -368,7 +339,6 @@ DECLFUNC(xthal_dcache_is_enabled)
 	movi	a2, 1
 	abi_return
 	endfunc
-# endif /*split*/
 
 #endif
 
@@ -378,8 +348,6 @@ DECLFUNC(xthal_dcache_is_enabled)
 // invalidate the icache
 //----------------------------------------------------------------------
 
-#if defined(__SPLIT__icache_all_invalidate) || \
-    defined(__SPLIT__icache_all_invalidate_nw)
 
 // void xthal_icache_all_invalidate(void);
 
@@ -394,10 +362,7 @@ DECLFUNC(xthal_icache_all_invalidate)
 // invalidate the dcache
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_all_invalidate) || \
-    defined(__SPLIT__dcache_all_invalidate_nw)
 
 // void xthal_dcache_all_invalidate(void);
 
@@ -411,10 +376,7 @@ DECLFUNC(xthal_dcache_all_invalidate)
 // write dcache dirty data
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_all_writeback) || \
-    defined(__SPLIT__dcache_all_writeback_nw)
 
 // void xthal_dcache_all_writeback(void);
 
@@ -428,10 +390,7 @@ DECLFUNC(xthal_dcache_all_writeback)
 // write dcache dirty data and invalidate
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_all_writeback_inv) || \
-    defined(__SPLIT__dcache_all_writeback_inv_nw)
 
 // void xthal_dcache_all_writeback_inv(void);
 
@@ -445,10 +404,7 @@ DECLFUNC(xthal_dcache_all_writeback_inv)
 // unlock instructions from icache
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__icache_all_unlock) || \
-    defined(__SPLIT__icache_all_unlock_nw)
 
 // void xthal_icache_all_unlock(void);
 
@@ -462,10 +418,7 @@ DECLFUNC(xthal_icache_all_unlock)
 // unlock data from dcache
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_all_unlock) || \
-    defined(__SPLIT__dcache_all_unlock_nw)
 
 // void xthal_dcache_all_unlock(void);
 
@@ -479,10 +432,7 @@ DECLFUNC(xthal_dcache_all_unlock)
 // invalidate the address range in the icache
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__icache_region_invalidate) || \
-    defined(__SPLIT__icache_region_invalidate_nw)
 
 // void xthal_icache_region_invalidate( void *addr, unsigned size );
 
@@ -493,48 +443,36 @@ DECLFUNC(xthal_icache_region_invalidate)
 	abi_return
 	endfunc
 
-#endif
 
-#if defined(__SPLIT__icache_hugerange_invalidate)
 
 // void xthal_icache_hugerange_invalidate( void *addr, unsigned size );
 icache_hugefunc	invalidate,	ihi
 
-#endif
 
-#if defined(__SPLIT__icache_hugerange_unlock)
 
 # if XCHAL_ICACHE_LINE_LOCKABLE
 // void xthal_icache_hugerange_unlock( void *addr, unsigned size );
 icache_hugefunc	unlock,		ihu
 # endif
 
-#endif
 
-#if defined(__SPLIT__dcache_hugerange_invalidate)
 
 // void xthal_dcache_hugerange_invalidate( void *addr, unsigned size );
 dcache_hugefunc	invalidate,	dhi
 
-#endif
 
-#if defined(__SPLIT__dcache_hugerange_unlock)
 
 # if XCHAL_DCACHE_LINE_LOCKABLE
 // void xthal_dcache_hugerange_unlock( void *addr, unsigned size );
 dcache_hugefunc	unlock,		dhu
 # endif
 
-#endif
 
-#if defined(__SPLIT__dcache_hugerange_writeback)
 
 // void xthal_dcache_hugerange_writeback( void *addr, unsigned size );
 dcache_hugefunc	writeback,	dhwb
 
-#endif
 
-#if defined(__SPLIT__dcache_hugerange_writeback_inv)
 
 // void xthal_dcache_hugerange_writeback_inv( void *addr, unsigned size );
 dcache_hugefunc	writeback_inv,	dhwbi
@@ -545,10 +483,7 @@ dcache_hugefunc	writeback_inv,	dhwbi
 // invalidate the address range in the dcache
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_region_invalidate) || \
-    defined(__SPLIT__dcache_region_invalidate_nw)
 
 // void xthal_dcache_region_invalidate( void *addr, unsigned size );
 
@@ -562,10 +497,7 @@ DECLFUNC(xthal_dcache_region_invalidate)
 // write dcache region dirty data
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_region_writeback) || \
-    defined(__SPLIT__dcache_region_writeback_nw)
 
 // void xthal_dcache_region_writeback( void *addr, unsigned size );
 
@@ -579,10 +511,7 @@ DECLFUNC(xthal_dcache_region_writeback)
 // write dcache region dirty data and invalidate
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_region_writeback_inv) || \
-	defined(__SPLIT__dcache_region_writeback_inv_nw)
 
 // void xthal_dcache_region_writeback_inv( void *addr, unsigned size );
 
@@ -596,10 +525,7 @@ DECLFUNC(xthal_dcache_region_writeback_inv)
 // lock instructions in icache region
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__icache_region_lock) || \
-	defined(__SPLIT__icache_region_lock_nw)
 
 // void xthal_icache_region_lock(void);
 
@@ -613,10 +539,7 @@ DECLFUNC(xthal_icache_region_lock)
 // lock data in dcache region
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_region_lock) || \
-	defined(__SPLIT__dcache_region_lock_nw)
 
 // void xthal_dcache_region_lock(void);
 
@@ -630,10 +553,7 @@ DECLFUNC(xthal_dcache_region_lock)
 // unlock instructions from icache region
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__icache_region_unlock) || \
-	defined(__SPLIT__icache_region_unlock_nw)
 
 // void xthal_icache_region_unlock(void);
 
@@ -647,10 +567,7 @@ DECLFUNC(xthal_icache_region_unlock)
 // unlock data from dcache region
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_region_unlock) || \
-	defined(__SPLIT__dcache_region_unlock_nw)
 
 // void xthal_dcache_region_unlock(void);
 
@@ -665,10 +582,7 @@ DECLFUNC(xthal_dcache_region_unlock)
 // invalidate single icache line
 //----------------------------------------------------------------------
 
-#endif
 
-#if	defined(__SPLIT__icache_line_invalidate) || \
-	defined(__SPLIT__icache_line_invalidate_nw)
 
 // void xthal_icache_line_invalidate(void *addr);
 
@@ -684,10 +598,7 @@ DECLFUNC(xthal_icache_line_invalidate)
 // invalidate single dcache line
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_line_invalidate) || \
-	defined(__SPLIT__dcache_line_invalidate_nw)
 
 // void xthal_dcache_line_invalidate(void *addr);
 
@@ -701,10 +612,7 @@ DECLFUNC(xthal_dcache_line_invalidate)
 // write single dcache line dirty data
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_line_writeback) || \
-	defined(__SPLIT__dcache_line_writeback_nw)
 
 // void xthal_dcache_line_writeback(void *addr);
 
@@ -718,10 +626,7 @@ DECLFUNC(xthal_dcache_line_writeback)
 // write single dcache line dirty data and invalidate
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_line_writeback_inv) || \
-	defined(__SPLIT__dcache_line_writeback_inv_nw)
 
 // void xthal_dcache_line_writeback_inv(void *addr);
 
@@ -735,10 +640,7 @@ DECLFUNC(xthal_dcache_line_writeback_inv)
 // lock instructions in icache line
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__icache_line_lock) || \
-	defined(__SPLIT__icache_line_lock_nw)
 
 // void xthal_icache_line_lock(void);
 
@@ -752,10 +654,7 @@ DECLFUNC(xthal_icache_line_lock)
 // lock data in dcache line
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_line_lock) || \
-	defined(__SPLIT__dcache_line_lock_nw)
 
 // void xthal_dcache_line_lock(void);
 
@@ -769,10 +668,7 @@ DECLFUNC(xthal_dcache_line_lock)
 // unlock instructions from icache line
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__icache_line_unlock) || \
-	defined(__SPLIT__icache_line_unlock_nw)
 
 // void xthal_icache_line_unlock(void);
 
@@ -786,10 +682,7 @@ DECLFUNC(xthal_icache_line_unlock)
 // unlock data from dcache line
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_line_unlock) || \
-	defined(__SPLIT__dcache_line_unlock_nw)
 
 // void xthal_dcache_line_unlock(void);
 
@@ -803,10 +696,7 @@ DECLFUNC(xthal_dcache_line_unlock)
 // sync icache and memory (???)
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__icache_sync) || \
-	defined(__SPLIT__icache_sync_nw)
 
 // void xthal_icache_sync(void);
 
@@ -821,10 +711,7 @@ DECLFUNC(xthal_icache_sync)
 // sync dcache and memory (???)
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__dcache_sync) || \
-	defined(__SPLIT__dcache_sync_nw)
 
 // void xthal_dcache_sync(void);
 
@@ -838,10 +725,7 @@ DECLFUNC(xthal_dcache_sync)
 // Get/Set icache number of ways enabled
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined (__SPLIT__icache_get_ways) || \
-	defined (__SPLIT__icache_get_ways_nw)
 
 // unsigned int xthal_icache_get_ways(void);
 
@@ -851,10 +735,7 @@ DECLFUNC(xthal_icache_get_ways)
 	abi_return
 	endfunc
 
-#endif
 
-#if defined (__SPLIT__icache_set_ways) || \
-	defined(__SPLIT__icache_set_ways_nw)
 
 /// void xthal_icache_set_ways(unsigned int ways);
 
@@ -868,10 +749,7 @@ DECLFUNC(xthal_icache_set_ways)
 // Get/Set dcache number of ways enabled
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined (__SPLIT__dcache_get_ways) || \
-	defined (__SPLIT__dcache_get_ways_nw)
 
 // unsigned int xthal_dcache_get_ways(void);
 
@@ -881,10 +759,7 @@ DECLFUNC(xthal_dcache_get_ways)
 	abi_return
 	endfunc
 
-#endif
 
-#if defined (__SPLIT__dcache_set_ways) || \
-	defined (__SPLIT__dcache_set_ways_nw)
 
 // void xthal_dcache_set_ways(unsigned int ways);
 
@@ -898,10 +773,7 @@ DECLFUNC(xthal_dcache_set_ways)
 // opt into and out of coherence
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__cache_coherence_on) || \
-	defined(__SPLIT__cache_coherence_on_nw)
 
 // The opt-in routine assumes cache was initialized at reset,
 // so it's equivalent to the low-level coherence_on routine.
@@ -916,10 +788,7 @@ DECLFUNC(xthal_cache_coherence_on)
 	abi_return
 	endfunc
 	
-#endif
 
-#if defined(__SPLIT__cache_coherence_off) || \
-	defined(__SPLIT__cache_coherence_off_nw)
 
 // The coherence_off routines should not normally be called directly.
 // Use the xthal_cache_coherence_optout() C routine instead
@@ -938,10 +807,7 @@ DECLFUNC(xthal_cache_coherence_off)
 // Control cache prefetch
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__set_cache_prefetch_long) || \
-	defined(__SPLIT__set_cache_prefetch_long_nw)
 
 # if XCHAL_HAVE_BE
 #  define aH a2	/* msb word = prefctl mask */
@@ -988,10 +854,7 @@ DECLFUNC(xthal_set_cache_prefetch_long)
 
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__set_cache_prefetch) || \
-	defined(__SPLIT__set_cache_prefetch_nw)
 
 // FOR BACKWARD COMPATIBILITY WITH PRE-RF RELEASE OBJECT CODE ONLY.
 // Set cache prefetch state (-1=enable, 0=disable, and see the
@@ -1026,10 +889,7 @@ DECLFUNC(xthal_set_cache_prefetch)
 
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__get_cache_prefetch) ||\
-	defined(__SPLIT__get_cache_prefetch_nw)
 
 // Return current cache prefetch state.
 // int  xthal_get_cache_prefetch( void )
@@ -1046,25 +906,16 @@ DECLFUNC(xthal_get_cache_prefetch)
 //----------------------------------------------------------------------
 // Misc configuration info
 //----------------------------------------------------------------------
-#endif
 
 // Eventually these will move to their own file:
-#if defined(__SPLIT__hw_configid0)
 	.set	xthals_hw_configid0, XCHAL_HW_CONFIGID0
-#endif
 
-#if defined(__SPLIT__hw_configid1)
 	.set	xthals_hw_configid1, XCHAL_HW_CONFIGID1
-#endif
 
-#if defined(__SPLIT__release_major)
 	.set	xthals_release_major, XTHAL_RELEASE_MAJOR
-#endif
 
-#if defined(__SPLIT__release_minor)
 	.set	xthals_release_minor, XTHAL_RELEASE_MINOR
 
-#endif /*split*/
 
 	.global	xthals_hw_configid0, xthals_hw_configid1
 	.global	xthals_release_major, xthals_release_minor

--- a/src/hal/disass.c
+++ b/src/hal/disass.c
@@ -33,7 +33,6 @@ extern const unsigned char Xthal_op0_format_lengths[16];
 extern const unsigned char Xthal_byte0_format_lengths[256];
 
 
-#if defined(__SPLIT__op0_format_lengths)
 
 /*  Instruction length in bytes as function of its op0 field (first nibble):  */
 #ifdef XCHAL_OP0_FORMAT_LENGTHS
@@ -43,7 +42,6 @@ const unsigned char Xthal_op0_format_lengths[16] = {
 #endif
 
 
-#elif defined(__SPLIT__byte0_format_lengths)
 
 /*  Instruction length in bytes as function of its first byte:  */
 const unsigned char Xthal_byte0_format_lengths[256] = {
@@ -51,7 +49,6 @@ const unsigned char Xthal_byte0_format_lengths[256] = {
 };
 
 
-#elif defined(__SPLIT__disassemble_size)
 
 //
 // Disassembly is currently not supported in xtensa hal.
@@ -74,7 +71,6 @@ int xthal_disassemble_size( unsigned char *instr_buf )
 }
 
 
-#elif defined(__SPLIT__disassemble)
 
 /*
  *  Note:  we make sure to avoid the use of library functions,
@@ -150,4 +146,3 @@ int xthal_disassemble(
 #undef OUTC
 
 
-#endif /*split*/

--- a/src/hal/int_asm.S
+++ b/src/hal/int_asm.S
@@ -42,8 +42,6 @@
 #endif /* XCHAL_HAVE_INTERRUPTS */
 
 
-#if defined(__SPLIT__get_intenable) || \
-    defined(__SPLIT__get_intenable_nw)
 
 //----------------------------------------------------------------------
 // Access INTENABLE register from C
@@ -61,10 +59,7 @@ DECLFUNC(xthal_get_intenable)
 	abi_return
 	endfunc
 
-#endif
 
-#if defined(__SPLIT__set_intenable) || \
-    defined(__SPLIT__set_intenable_nw)
 
 // void xthal_set_intenable(unsigned)
 //
@@ -81,10 +76,7 @@ DECLFUNC(xthal_set_intenable)
 // Access INTERRUPT, INTSET, INTCLEAR register from C
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__get_interrupt) || \
-    defined (__SPLIT__get_interrupt_nw)
 
 // unsigned xthal_get_interrupt(void)
 //
@@ -98,10 +90,7 @@ DECLFUNC (xthal_get_interrupt)
 	abi_return
 	endfunc
 
-#endif
 
-#if defined(__SPLIT__get_intread) || \
-    defined(__SPLIT__get_intread_nw)
 
 DECLFUNC (xthal_get_intread)
 	abi_entry
@@ -113,10 +102,7 @@ DECLFUNC (xthal_get_intread)
 	abi_return
 	endfunc
 
-#endif
 
-#if defined(__SPLIT__set_intset) || \
-    defined(__SPLIT__set_intset_nw)
 
 // void xthal_set_intset(unsigned)
 //
@@ -128,10 +114,6 @@ DECLFUNC(xthal_set_intset)
 	abi_return
 	endfunc
 
-#endif
-
-#if defined(__SPLIT__set_intclear) || \
-    defined(__SPLIT__set_intclear_nw)
 
 // void xthal_set_intclear(unsigned)
 //
@@ -151,10 +133,7 @@ DECLFUNC(xthal_set_intclear)
 // using INTENABLE to simulate the masking that PS.INTLEVEL would do.
 //----------------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__get_vpri) ||\
-    defined(__SPLIT__get_vpri_nw)
 
 // unsigned xthal_get_vpri(void);
 
@@ -169,9 +148,6 @@ DECLFUNC(xthal_get_vpri)
 	abi_return
 	endfunc
 
-#endif
-
-#if defined(__SPLIT__set_vpri_nw)
 
 // unsigned xthal_set_vpri_nw(unsigned)
 //
@@ -276,9 +252,7 @@ _SYM(xthal_set_vpri_intlevel_nw)
 
 
 
-#endif
 
-#if defined(__SPLIT__set_vpri)
 
 // unsigned  xthal_set_vpri (unsigned newvpri);
 //
@@ -377,9 +351,7 @@ DECLFUNC(xthal_set_vpri_lock)
 	endfunc
 
 
-#endif
 
-#if defined(__SPLIT__get_intpending_nw)
 
 // unsigned xthal_get_intpending_nw(void)
 //
@@ -568,10 +540,7 @@ gipfail:
 
 // -----------------------------------------------------------------
 
-#endif
 
-#if defined(__SPLIT__vpri_lock) || \
-    defined(__SPLIT__vpri_lock_nw)
 
 // void xthal_vpri_lock()
 //
@@ -607,10 +576,7 @@ xthal_vpri_lock_done:
 	abi_return
 	endfunc
 
-#endif
 
-#if defined(__SPLIT__vpri_unlock) || \
-    defined(__SPLIT__vpri_unlock_nw)
 
 // void xthal_vpri_unlock(void)
 //
@@ -639,5 +605,4 @@ DECLFUNC(xthal_vpri_unlock)
 	abi_return
 	endfunc
 
-#endif /*SPLIT*/
 

--- a/src/hal/interrupts.c
+++ b/src/hal/interrupts.c
@@ -155,81 +155,62 @@ Combined refs:
 
 
 
-#if   defined(__SPLIT__num_intlevels)
 
 // the number of interrupt levels
 const unsigned char Xthal_num_intlevels = XCHAL_NUM_INTLEVELS;
 
-#endif
 
-#if defined(__SPLIT__num_interrupts)
 
 // the number of interrupts
 const unsigned char Xthal_num_interrupts = XCHAL_NUM_INTERRUPTS;
 
-#endif
 
-#if defined(__SPLIT__excm_level)
 
 // the highest level of interrupts masked by PS.EXCM (if XEA2)
 const unsigned char Xthal_excm_level = XCHAL_EXCM_LEVEL;
 
-#endif
 
-#if defined(__SPLIT__intlevel_mask)
 
 // mask of interrupts at each intlevel
 const unsigned Xthal_intlevel_mask[16] = { 
     XCHAL_INTLEVEL_MASKS
 };
 
-#endif
 
-#if defined(__SPLIT__intlevel_andbelow_mask)
 
 // mask for level 1 to N interrupts
 const unsigned Xthal_intlevel_andbelow_mask[16] = { 
     XCHAL_INTLEVEL_ANDBELOW_MASKS
 };
 
-#endif
 
-#if defined(__SPLIT__intlevel)
 
 // level per interrupt
 const unsigned char Xthal_intlevel[32] = { 
     XCHAL_INT_LEVELS
 };
 
-#endif
 
-#if defined(__SPLIT__inttype)
 
 // type of each interrupt
 const unsigned char Xthal_inttype[32] = {
     XCHAL_INT_TYPES
 };
 
-#endif
 
-#if defined(__SPLIT__inttype_mask)
 
 const unsigned Xthal_inttype_mask[XTHAL_MAX_INTTYPES] = {
     XCHAL_INTTYPE_MASKS
 };
 
-#endif
 
-#if defined(__SPLIT__timer_interrupt)
 
 // interrupts assigned to each timer (CCOMPARE0 to CCOMPARE3), -1 if unassigned
 const int Xthal_timer_interrupt[XTHAL_MAX_TIMERS] = { 
     XCHAL_TIMER_INTERRUPTS
 };
 
-#endif
 
-#if defined(__SPLIT__vpri)
 
 #if XCHAL_HAVE_INTERRUPTS
 
@@ -402,9 +383,7 @@ XtHalVoidFunc *Xthal_tram_trigger_fn = xthal_null_func;
 
 #endif /* XCHAL_HAVE_INTERRUPTS */
 
-#endif
 
-#if defined(__SPLIT__vpri_to_intlevel)
 
 /*
  *  xthal_vpri_to_intlevel
@@ -421,9 +400,7 @@ unsigned xthal_vpri_to_intlevel(unsigned vpri)
 #endif
 }
 
-#endif
 
-#if defined(__SPLIT__intlevel_to_vpri)
 
 /*
  *  xthal_intlevel_to_vpri
@@ -439,9 +416,7 @@ unsigned xthal_intlevel_to_vpri(unsigned intlevel)
 #endif
 }
 
-#endif
 
-#if defined(__SPLIT__vpri_int_enable)
 
 /*
  *  xthal_int_enable
@@ -485,9 +460,7 @@ unsigned xthal_int_enable(unsigned mask)
 #endif /* XCHAL_HAVE_INTERRUPTS */
 }
 
-#endif
 
-#if defined(__SPLIT__vpri_int_disable)
 
 /*
  *  xthal_int_disable
@@ -510,9 +483,7 @@ unsigned xthal_int_disable(unsigned mask)
 #endif
 }
 
-#endif
 
-#if defined(__SPLIT__set_vpri_locklevel)
 
 void  xthal_set_vpri_locklevel(unsigned intlevel)
 {
@@ -526,9 +497,7 @@ void  xthal_set_vpri_locklevel(unsigned intlevel)
 #endif
 }
 
-#endif
 
-#if defined(__SPLIT__get_vpri_locklevel)
 
 unsigned  xthal_get_vpri_locklevel(void)
 {
@@ -539,9 +508,7 @@ unsigned  xthal_get_vpri_locklevel(void)
 #endif
 }
 
-#endif
 
-#if defined(__SPLIT__set_int_vpri)
 
 /*
  *  xthal_set_int_vpri   (was intSetL1Pri)
@@ -625,9 +592,7 @@ int  xthal_set_int_vpri(int intnum, int vpri)
 #endif /* XCHAL_HAVE_INTERRUPTS */
 } /* xthal_set_int_vpri */
 
-#endif
 
-#if defined(__SPLIT__get_int_vpri)
 
 int	xthal_get_int_vpri(int intnum)
 {
@@ -641,9 +606,7 @@ int	xthal_get_int_vpri(int intnum)
 }
 
 
-#endif
 
-#if defined(__SPLIT__trampolines)
 
 
 	/*
@@ -823,9 +786,7 @@ void  xthal_tram_done( unsigned serviced_mask )
 #endif
 }
 
-#endif
 
-#if defined(__SPLIT__deprecated)
 
 
 /**********************************************************************/
@@ -846,5 +807,4 @@ const unsigned Xthal_int_type_software = XCHAL_INTTYPE_MASK_SOFTWARE;
 #endif /* INCLUDE_DEPRECATED_HAL_CODE */
 
 
-#endif /* SPLITs */
 

--- a/src/hal/mem_ecc_parity.S
+++ b/src/hal/mem_ecc_parity.S
@@ -72,7 +72,6 @@
 //  Inject errors into instruction and/or data RAMs, or cache data or tags
 //------------------------------------------------------------------------
 
-#if defined(__SPLIT__memep_inject_error)
 
 // void xthal_memep_inject_error(void *addr, int size, int flags);
 // where:
@@ -279,7 +278,6 @@ SYMBOL(xthal_memep_inject_error)
 	.size	xthal_memep_inject_error, . - xthal_memep_inject_error
 
 
-#endif /*split*/
 
 //----------------------------------------------------------------------
 

--- a/src/hal/miscellaneous.S
+++ b/src/hal/miscellaneous.S
@@ -39,8 +39,6 @@
 // System Software Reference Manual for details on the use of this function.
 //----------------------------------------------------------------------
 
-#if defined(__SPLIT__clear_regcached_code) || \
-    defined(__SPLIT__clear_regcached_code_nw)
 
 DECLFUNC(xthal_clear_regcached_code)
 	abi_entry
@@ -52,5 +50,4 @@ DECLFUNC(xthal_clear_regcached_code)
 	abi_return
 	endfunc
 
-#endif
 

--- a/src/hal/state.c
+++ b/src/hal/state.c
@@ -29,14 +29,11 @@
 
 //----------------------------------------------------------------------
 
-#if defined(__SPLIT__extra_size)
 // space for "extra" (user special registers and non-coprocessor TIE) state:
 const unsigned int Xthal_extra_size = XCHAL_NCP_SA_SIZE;
 
-#elif defined(__SPLIT__extra_align)
 const unsigned int Xthal_extra_align = XCHAL_NCP_SA_ALIGN;
 
-#elif defined(__SPLIT__cpregs_size)
 // space for state of TIE coprocessors:
 const unsigned int Xthal_cpregs_size[8] =
 	{
@@ -50,7 +47,6 @@ const unsigned int Xthal_cpregs_size[8] =
 	    XCHAL_CP7_SA_SIZE
 	};
 
-#elif defined(__SPLIT__cpregs_align)
 const unsigned int Xthal_cpregs_align[8] =
 	{
 	    XCHAL_CP0_SA_ALIGN,
@@ -63,7 +59,6 @@ const unsigned int Xthal_cpregs_align[8] =
 	    XCHAL_CP7_SA_ALIGN
 	};
 
-#elif defined(__SPLIT__cp_names)
 const char * const Xthal_cp_names[8] =
 	{
 	    XCHAL_CP0_NAME,
@@ -76,35 +71,28 @@ const char * const Xthal_cp_names[8] =
 	    XCHAL_CP7_NAME
 	};
 
-#elif defined(__SPLIT__all_extra_size)
 // total save area size (extra + all coprocessors + min 16-byte alignment everywhere)
 const unsigned int Xthal_all_extra_size = XCHAL_TOTAL_SA_SIZE;
 
-#elif defined(__SPLIT__all_extra_align)
 // maximum required alignment for the total save area (this might be useful):
 const unsigned int Xthal_all_extra_align = XCHAL_TOTAL_SA_ALIGN;
 
-#elif defined(__SPLIT__num_coprocessors)
 // number of coprocessors starting contiguously from zero
 // (same as Xthal_cp_max, but included for Tornado2):
 const unsigned int Xthal_num_coprocessors = XCHAL_CP_MAX;
 
-#elif defined(__SPLIT__cp_num)
 // actual number of coprocessors:
 const unsigned char Xthal_cp_num    = XCHAL_CP_NUM;
 
-#elif defined(__SPLIT__cp_max)
 // index of highest numbered coprocessor, plus one:
 const unsigned char Xthal_cp_max    = XCHAL_CP_MAX;
 
 // index of highest allowed coprocessor number, per cfg, plus one:
 //const unsigned char Xthal_cp_maxcfg = XCHAL_CP_MAXCFG;
 
-#elif defined(__SPLIT__cp_mask)
 // bitmask of which coprocessors are present:
 const unsigned int  Xthal_cp_mask   = XCHAL_CP_MASK;
 
-#elif defined(__SPLIT__cp_id_mappings)
 // Coprocessor ID from its name
 
 # ifdef XCHAL_CP0_IDENT
@@ -132,7 +120,6 @@ const unsigned char XCJOIN(Xthal_cp_id_,XCHAL_CP6_IDENT) = 6;
 const unsigned char XCJOIN(Xthal_cp_id_,XCHAL_CP7_IDENT) = 7;
 # endif
 
-#elif defined(__SPLIT__cp_mask_mappings)
 // Coprocessor "mask" (1 << ID) from its name
 
 # ifdef XCHAL_CP0_IDENT
@@ -162,7 +149,6 @@ const unsigned int  XCJOIN(Xthal_cp_mask_,XCHAL_CP7_IDENT) = (1 << 7);
 
 //----------------------------------------------------------------------
 
-#elif defined(__SPLIT__init_mem_extra)
 // CMS: I have made the assumptions that 0's are safe initial
 // values. That may be wrong at some point.
 //
@@ -183,7 +169,6 @@ xthal_init_mem_extra(void *address)
     } 
 }
 
-#elif defined(__SPLIT__init_mem_cp)
 // initialize the TIE coprocessor
 void
 xthal_init_mem_cp(void *address, int cp)
@@ -202,7 +187,6 @@ xthal_init_mem_cp(void *address, int cp)
     }
 }
 
-#endif /*splitting*/
 
 
 /*  Nothing implemented below this point.  */

--- a/src/hal/state_asm.S
+++ b/src/hal/state_asm.S
@@ -33,8 +33,7 @@
 // 		save the extra processor state.
 //----------------------------------------------------------------------
 
-#if defined(__SPLIT__save_extra) ||\
-    defined(__SPLIT__save_extra_nw)
+
 
 // void xthal_save_extra(void *base)
 
@@ -49,8 +48,7 @@ DECLFUNC(xthal_save_extra)
 // 		restore the extra processor state.
 //----------------------------------------------------------------------
 
-#elif 	defined(__SPLIT__restore_extra) ||\
-	defined(__SPLIT__restore_extra_nw)
+
 	
 // void xthal_restore_extra(void *base)
 
@@ -64,8 +62,7 @@ DECLFUNC(xthal_restore_extra)
 // 		save the TIE COPROCESSORS state
 //----------------------------------------------------------------------
 
-#elif 	defined(__SPLIT__save_cpregs) ||\
-	defined(__SPLIT__save_cpregs_nw)
+
 
 // void xthal_save_cpregs(void *base, int)
 DECLFUNC(xthal_save_cpregs)
@@ -73,64 +70,56 @@ DECLFUNC(xthal_save_cpregs)
 	xchal_cpi_store_funcbody
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp0) ||\
-	defined(__SPLIT__save_cp0_nw)
+
 // void xthal_save_cp0(void *base)
 DECLFUNC(xthal_save_cp0)
 	abi_entry
 	xchal_cp0_store_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp1) ||\
-	defined(__SPLIT__save_cp1_nw)
+
 // void xthal_save_cp1(void *base)
 DECLFUNC(xthal_save_cp1)
 	abi_entry
 	xchal_cp1_store_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp2) ||\
-	defined(__SPLIT__save_cp2_nw)
+
 // void xthal_save_cp2(void *base)
 DECLFUNC(xthal_save_cp2)
 	abi_entry
 	xchal_cp2_store_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp3) ||\
-	defined(__SPLIT__save_cp3_nw)
+
 // void xthal_save_cp3(void *base)
 DECLFUNC(xthal_save_cp3)
 	abi_entry
 	xchal_cp3_store_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp4) ||\
-	defined(__SPLIT__save_cp4_nw)
+
 // void xthal_save_cp4(void *base)
 DECLFUNC(xthal_save_cp4)
 	abi_entry
 	xchal_cp4_store_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp5) ||\
-	defined(__SPLIT__save_cp5_nw)
+
 // void xthal_save_cp5(void *base)
 DECLFUNC(xthal_save_cp5)
 	abi_entry
 	xchal_cp5_store_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp6) || \
-	defined(__SPLIT__save_cp6_nw)
+
 // void xthal_save_cp6(void *base)
 DECLFUNC(xthal_save_cp6)
 	abi_entry
 	xchal_cp6_store_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__save_cp7) ||\
-	defined(__SPLIT__save_cp7_nw)
+
 // void xthal_save_cp7(void *base)
 DECLFUNC(xthal_save_cp7)
 	abi_entry
@@ -142,8 +131,7 @@ DECLFUNC(xthal_save_cp7)
 // 		restore the TIE coprocessor state
 //----------------------------------------------------------------------
 
-#elif 	defined(__SPLIT__restore_cpregs) ||\
-	defined(__SPLIT__restore_cpregs_nw)
+
 
 // void xthal_restore_cpregs(void *base, int)
 
@@ -152,64 +140,56 @@ DECLFUNC(xthal_restore_cpregs)
 	xchal_cpi_load_funcbody
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp0) ||\
-	defined(__SPLIT__restore_cp0_nw)
+
 // void xthal_restore_cp0(void *base)
 DECLFUNC(xthal_restore_cp0)
 	abi_entry
 	xchal_cp0_load_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp1) ||\
-	defined(__SPLIT__restore_cp1_nw)
+
 // void xthal_restore_cp1(void *base)
 DECLFUNC(xthal_restore_cp1)
 	abi_entry
 	xchal_cp1_load_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp2) ||\
-	defined(__SPLIT__restore_cp2_nw)
+
 // void xthal_restore_cp2(void *base)
 DECLFUNC(xthal_restore_cp2)
 	abi_entry
 	xchal_cp2_load_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp3) || \
-	defined(__SPLIT__restore_cp3_nw)
+
 // void xthal_restore_cp3(void *base)
 DECLFUNC(xthal_restore_cp3)
 	abi_entry
 	xchal_cp3_load_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp4) || \
-	defined(__SPLIT__restore_cp4_nw)
+
 // void xthal_restore_cp4(void *base)
 DECLFUNC(xthal_restore_cp4)
 	abi_entry
 	xchal_cp4_load_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp5) || \
-	defined(__SPLIT__restore_cp5_nw)
+
 // void xthal_restore_cp5(void *base)
 DECLFUNC(xthal_restore_cp5)
 	abi_entry
 	xchal_cp5_load_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp6) || \
-	defined(__SPLIT__restore_cp6_nw)
+
 // void xthal_restore_cp6(void *base)
 DECLFUNC(xthal_restore_cp6)
 	abi_entry
 	xchal_cp6_load_a2
 	abi_return
 	endfunc
-#elif 	defined(__SPLIT__restore_cp7) || \
-	defined(__SPLIT__restore_cp7_nw)
+
 // void xthal_restore_cp7(void *base)
 DECLFUNC(xthal_restore_cp7)
 	abi_entry
@@ -217,7 +197,7 @@ DECLFUNC(xthal_restore_cp7)
 	abi_return
 	endfunc
 
-#elif defined(__SPLIT__cpregs_save_fn)
+
 	.section .rodata, "a"
 _SYM(Xthal_cpregs_save_fn)
 # ifdef __XTENSA_CALL0_ABI__
@@ -234,7 +214,7 @@ _SYM(Xthal_cpregs_save_nw_fn)
 	endfunc
 	.text
 
-#elif defined(__SPLIT__cpregs_save_nw_fn)
+
 # ifndef __XTENSA_CALL0_ABI__
 	.section .rodata, "a"
 _SYM(Xthal_cpregs_save_nw_fn)
@@ -250,7 +230,7 @@ _SYM(Xthal_cpregs_save_nw_fn)
 	.text
 # endif
 
-#elif defined(__SPLIT__cpregs_restore_fn)
+
 	.section .rodata, "a"
 _SYM(Xthal_cpregs_restore_fn)
 # ifdef __XTENSA_CALL0_ABI__
@@ -267,7 +247,7 @@ _SYM(Xthal_cpregs_restore_nw_fn)
 	endfunc
 	.text
 
-#elif defined(__SPLIT__cpregs_restore_nw_fn)
+
 # ifndef __XTENSA_CALL0_ABI__
 	.section .rodata, "a"
 _SYM(Xthal_cpregs_restore_nw_fn)
@@ -288,8 +268,7 @@ _SYM(Xthal_cpregs_restore_nw_fn)
 //		coprocessor enable/disable
 //----------------------------------------------------------------------
 
-#elif 	defined(__SPLIT__validate_cp) ||\
-	defined(__SPLIT__validate_cp_nw)
+
 
 // validate the register file.
 // void xthal_validate_cp(int)
@@ -307,8 +286,7 @@ DECLFUNC(xthal_validate_cp)
 	abi_return
 	endfunc
 
-#elif 	defined(__SPLIT__invalidate_cp) || \
-	defined(__SPLIT__invalidate_cp_nw)
+
 
 // invalidate the register file.
 // void xthal_invalidate_cp(int)
@@ -332,8 +310,7 @@ DECLFUNC(xthal_invalidate_cp)
 //  Access the CPENABLE register
 //----------------------------------------------------------------------
 
-#elif 	defined(__SPLIT__get_cpenable) || \
-	defined(__SPLIT__get_cpenable_nw)
+
 
 // unsigned xthal_get_cpenable(void);
 
@@ -347,8 +324,7 @@ DECLFUNC(xthal_get_cpenable)
 	abi_return
 	endfunc
 
-#elif 	defined(__SPLIT__set_cpenable) ||\
-	defined(__SPLIT__set_cpenable_nw)
+
 
 // void xthal_set_cpenable(unsigned);
 //
@@ -371,7 +347,6 @@ DECLFUNC(xthal_set_cpenable)
 #endif
 	abi_return
 	endfunc
-#endif
 
 
 /*  Nothing implemented below this point.  */


### PR DESCRIPTION
The new HAL still uses __SPLIT__ macros that need to be removed for Zephyr. Remove these.
Also add a README to help others to make future HAL updates.