### PR TITLE
hal: export hal as named library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CONFIG_XTENSA_HAL)
   target_include_directories(XTENSA_HAL INTERFACE include)
   target_include_directories(XTENSA_HAL INTERFACE zephyr/soc/${SOC_NAME}/)
 
-  zephyr_library()
+  zephyr_library_named(modules_xtensa_hal)
 
   zephyr_include_directories(
     include


### PR DESCRIPTION
Export the HAL as a named library so it can be used as a dependency
by board and SoC makefiles (instead of the SDK HAL).

Signed-off-by: Daniel Leung <daniel.leung@intel.com>
Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>