### PR TITLE
zephyr: update SoC overlay intel_ace15_mtpm

### DIFF
--- a/zephyr/soc/intel_ace15_mtpm/xtensa/config/core-isa.h
+++ b/zephyr/soc/intel_ace15_mtpm/xtensa/config/core-isa.h
@@ -7,7 +7,7 @@
 
 /* Xtensa processor core configuration information.
 
-   Customer ID=10631; Build=0x863b0; Copyright (c) 1999-2019 Tensilica Inc.
+   Copyright (c) 1999-2022 Tensilica Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -28,8 +28,8 @@
    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#ifndef _XTENSA_CORE_CONFIGURATION_H
-#define _XTENSA_CORE_CONFIGURATION_H
+#ifndef XTENSA_CORE_CONFIGURATION_H_
+#define XTENSA_CORE_CONFIGURATION_H_
 
 
 /****************************************************************************
@@ -73,8 +73,6 @@
 #define XCHAL_HAVE_PREDICTED_BRANCHES	0	/* B[EQ/EQZ/NE/NEZ]T instr's */
 #define XCHAL_HAVE_CALL4AND12		1	/* (obsolete option) */
 #define XCHAL_HAVE_ABS			1	/* ABS instruction */
-/*#define XCHAL_HAVE_POPC		0*/	/* POPC instruction */
-/*#define XCHAL_HAVE_CRC		0*/	/* CRC instruction */
 #define XCHAL_HAVE_RELEASE_SYNC		1	/* L32AI/S32RI instructions */
 #define XCHAL_HAVE_S32C1I		1	/* S32C1I instruction */
 #define XCHAL_HAVE_SPECULATION		0	/* speculation */
@@ -95,8 +93,13 @@
 #define XCHAL_HAVE_CP			1	/* CPENABLE reg (coprocessor) */
 #define XCHAL_CP_MAXCFG			2	/* max allowed cp id plus one */
 #define XCHAL_HAVE_MAC16		0	/* MAC16 package */
+#define XCHAL_HAVE_LX			1	/* LX core */
+#define XCHAL_HAVE_NX			0	/* NX core (starting RH) */
+#define XCHAL_HAVE_RNX 			0	/* RNX core (starting RJ) */
 
-#define XCHAL_HAVE_FUSION		0	/* Fusion*/
+#define XCHAL_HAVE_SUPERGATHER		0	/* SuperGather */
+
+#define XCHAL_HAVE_FUSION		0                      /* Fusion */
 #define XCHAL_HAVE_FUSION_FP		0	/* Fusion FP option */
 #define XCHAL_HAVE_FUSION_LOW_POWER	0	/* Fusion Low Power option */
 #define XCHAL_HAVE_FUSION_AES		0	/* Fusion BLE/Wifi AES-128 CCM option */
@@ -118,9 +121,12 @@
 #define XCHAL_HAVE_HIFI3_VFPU		0	/* HiFi3 Audio Engine VFPU option */
 #define XCHAL_HAVE_HIFI3Z		0	/* HiFi3Z Audio Engine pkg */
 #define XCHAL_HAVE_HIFI3Z_VFPU	0	/* HiFi3Z Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI1		0	/* HiFi1 */
+#define XCHAL_HAVE_HIFI1_VFPU		0	/* HiFi1 VFPU option */
+#define XCHAL_HAVE_HIFI1_LOW_LATENCY_MAC_FMA		0	/* HiFi1 Low-latency MAC/FMA option */
 #define XCHAL_HAVE_HIFI2		0	/* HiFi2 Audio Engine pkg */
 #define XCHAL_HAVE_HIFI2EP		0	/* HiFi2EP */
-#define XCHAL_HAVE_HIFI_MINI		0	
+#define XCHAL_HAVE_HIFI_MINI		0
 
 
 
@@ -152,20 +158,41 @@
 #define XCHAL_HAVE_FUSIONG_DP_VFPU	0    /* dp_vfpu option on FusionG */
 #define XCHAL_FUSIONG_SIMD32		0    /* simd32 for FusionG */
 
-#define XCHAL_HAVE_PDX			0    /* PDX */
+#define XCHAL_HAVE_FUSIONJ		0    /* FusionJ */
+#define XCHAL_HAVE_FUSIONJ6		0    /* FusionJ6 */
+#define XCHAL_HAVE_FUSIONJ_SP_VFPU	0    /* sp_vfpu option on FusionJ */
+#define XCHAL_HAVE_FUSIONJ_DP_VFPU	0    /* dp_vfpu option on FusionJ */
+#define XCHAL_FUSIONJ_SIMD32		0    /* simd32 for FusionJ */
+
+#define XCHAL_HAVE_PDX			0    /* PDX-LX */
 #define XCHAL_PDX_SIMD32		0    /* simd32 for PDX */
-#define XCHAL_HAVE_PDX4			0    /* PDX4 */
-#define XCHAL_HAVE_PDX8			0    /* PDX8 */
-#define XCHAL_HAVE_PDX16		0    /* PDX16 */
+#define XCHAL_HAVE_PDX4			0    /* PDX4-LX */
+#define XCHAL_HAVE_PDX8			0    /* PDX8-LX */
+#define XCHAL_HAVE_PDX16		0    /* PDX16-LX */
+#define XCHAL_HAVE_PDXNX 		0    /* PDX-NX */
 
 #define XCHAL_HAVE_CONNXD2		0	/* ConnX D2 pkg */
 #define XCHAL_HAVE_CONNXD2_DUALLSFLIX   0	/* ConnX D2 & Dual LoadStore Flix */
+#define XCHAL_HAVE_BALL			0
+#define XCHAL_HAVE_BALLAP		0
 #define XCHAL_HAVE_BBE16		0	/* ConnX BBE16 pkg */
 #define XCHAL_HAVE_BBE16_RSQRT		0	/* BBE16 & vector recip sqrt */
 #define XCHAL_HAVE_BBE16_VECDIV		0	/* BBE16 & vector divide */
 #define XCHAL_HAVE_BBE16_DESPREAD	0	/* BBE16 & despread */
+#define XCHAL_HAVE_CONNX_B10            0    /* ConnX B10 pkg*/
+#define XCHAL_HAVE_CONNX_B20            0    /* ConnX B20 pkg*/
+#define XCHAL_HAVE_CONNX_B_DP_VFPU      0    /* Double-precision Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_DPX_VFPU     0    /* Double-precision Vector Floating-point option on FP Machine*/
+#define XCHAL_HAVE_CONNX_B_SP_VFPU      0    /* Single-precision Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_SPX_VFPU     0    /* Single-precision Extended Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_HP_VFPU      0    /* Half-precision Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_HPX_VFPU     0    /* Half-precision Extended Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_32B_MAC      0    /* 32-bit vector MAC (real and complex), FIR & FFT option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_VITERBI      0    /* Viterbi option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_TURBO        0    /* Turbo option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_LDPC         0    /* LDPC option on ConnX B10 & B20 */
 #define XCHAL_HAVE_BBENEP		0	/* ConnX BBENEP pkgs */
-#define XCHAL_HAVE_BBENEP_SP_VFPU	0      /* sp_vfpu option on BBE-EP */
+#define XCHAL_HAVE_BBENEP_SP_VFPU	0       /* sp_vfpu option on BBE-EP */
 #define XCHAL_HAVE_BSP3			0	/* ConnX BSP3 pkg */
 #define XCHAL_HAVE_BSP3_TRANSPOSE	0	/* BSP3 & transpose32x32 */
 #define XCHAL_HAVE_SSP16		0	/* ConnX SSP16 pkg */
@@ -178,13 +205,19 @@
 
 #define XCHAL_HAVE_VISION	        0     /* Vision P5/P6 */
 #define XCHAL_VISION_SIMD16             0     /* simd16 for Vision P5/P6 */
-#define XCHAL_VISION_TYPE               0     /* Vision P5, P6, or P3 */
+#define XCHAL_VISION_TYPE               0     /* Vision P5, P6, Q6, Q7 or Q8 */
 #define XCHAL_VISION_QUAD_MAC_TYPE      0     /* quad_mac option on Vision P6 */
 #define XCHAL_HAVE_VISION_HISTOGRAM     0     /* histogram option on Vision P5/P6 */
-#define XCHAL_HAVE_VISION_SP_VFPU       0     /* sp_vfpu option on Vision P5/P6 */
-#define XCHAL_HAVE_VISION_HP_VFPU       0     /* hp_vfpu option on Vision P6 */
+#define XCHAL_HAVE_VISION_DP_VFPU       0     /* dp_vfpu option on Vision Q7/Q8 */
+#define XCHAL_HAVE_VISION_SP_VFPU       0     /* sp_vfpu option on Vision P5/P6/Q6/Q7 */
+#define XCHAL_HAVE_VISION_SP_VFPU_2XFMAC 0     /* sp_vfpu_2xfma option on Vision Q7 */
+#define XCHAL_HAVE_VISION_HP_VFPU       0     /* hp_vfpu option on Vision P6/Q6 */
+#define XCHAL_HAVE_VISION_HP_VFPU_2XFMAC 0     /* hp_vfpu_2xfma option on Vision Q7 */
 
 #define XCHAL_HAVE_VISIONC	        0     /* Vision C */
+
+#define XCHAL_HAVE_XNNE			0		/* XNNE */
+
 
 /*----------------------------------------------------------------------
 				MISC
@@ -204,35 +237,52 @@
 #define XCHAL_UNALIGNED_LOAD_HW		0	/* unaligned loads work in hw */
 #define XCHAL_UNALIGNED_STORE_HW	0	/* unaligned stores work in hw*/
 
-#define XCHAL_SW_VERSION		1200012	/* sw version of this header */
+#define XCHAL_UNIFIED_LOADSTORE         0
 
-#define XCHAL_CORE_ID			"mtl_LX7HiFi4"	/* alphanum core name
+#define XCHAL_SW_VERSION		1410000	/* sw version of this header */
+#define XCHAL_SW_VERSION_MAJOR		14000	/* major ver# of sw          */
+#define XCHAL_SW_VERSION_MINOR		10	/* minor ver# of sw          */
+#define XCHAL_SW_VERSION_MICRO		0	/* micro ver# of sw          */
+#define XCHAL_SW_MINOR_VERSION		1410000	/* with zeroed micro */
+#define XCHAL_SW_MICRO_VERSION		1410000
+
+#define XCHAL_CORE_ID			"ace10_LX7HiFi4_2022_10"	/* alphanum core name
 						   (CoreID) set in the Xtensa
 						   Processor Generator */
 
-#define XCHAL_BUILD_UNIQUE_ID		0x000863B0	/* 22-bit sw build ID */
+#define XCHAL_BUILD_UNIQUE_ID		0x000A315C	/* 22-bit sw build ID */
 
 /*
  *  These definitions describe the hardware targeted by this software.
  */
-#define XCHAL_HW_CONFIGID0		0xC2B3FBFE	/* ConfigID hi 32 bits*/
-#define XCHAL_HW_CONFIGID1		0x230863B0	/* ConfigID lo 32 bits*/
-#define XCHAL_HW_VERSION_NAME		"LX7.0.12"	/* full version name */
-#define XCHAL_HW_VERSION_MAJOR		2700	/* major ver# of targeted hw */
-#define XCHAL_HW_VERSION_MINOR		12	/* minor ver# of targeted hw */
-#define XCHAL_HW_VERSION		270012	/* major*100+minor */
+#define XCHAL_HW_CONFIGID0		0xC203B286	/* ConfigID hi 32 bits*/
+#define XCHAL_HW_CONFIGID1		0x29C95BA2	/* ConfigID lo 32 bits*/
+#define XCHAL_HW_VERSION_NAME		"LX7.1.7"	/* full version name */
+#define XCHAL_HW_VERSION_MAJOR		2810	/* major ver# of targeted hw */
+#define XCHAL_HW_VERSION_MINOR		7	/* minor ver# of targeted hw */
+#define XCHAL_HW_VERSION_MICRO		0	/* subdot ver# of targeted hw */
+#define XCHAL_HW_VERSION		281070	/* major*100+(major<2810 ? minor : minor*10+micro) */
 #define XCHAL_HW_REL_LX7		1
-#define XCHAL_HW_REL_LX7_0		1
-#define XCHAL_HW_REL_LX7_0_12		1
+#define XCHAL_HW_REL_LX7_1		1
+#define XCHAL_HW_REL_LX7_1_7		1
 #define XCHAL_HW_CONFIGID_RELIABLE	1
 /*  If software targets a *range* of hardware versions, these are the bounds: */
-#define XCHAL_HW_MIN_VERSION_MAJOR	2700	/* major v of earliest tgt hw */
-#define XCHAL_HW_MIN_VERSION_MINOR	12	/* minor v of earliest tgt hw */
-#define XCHAL_HW_MIN_VERSION		270012	/* earliest targeted hw */
-#define XCHAL_HW_MAX_VERSION_MAJOR	2700	/* major v of latest tgt hw */
-#define XCHAL_HW_MAX_VERSION_MINOR	12	/* minor v of latest tgt hw */
-#define XCHAL_HW_MAX_VERSION		270012	/* latest targeted hw */
+#define XCHAL_HW_MIN_VERSION_MAJOR	2810	/* major v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MINOR	7	/* minor v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MICRO	0	/* micro v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION		281070	/* earliest targeted hw */
+#define XCHAL_HW_MAX_VERSION_MAJOR	2810	/* major v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MINOR	7	/* minor v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MICRO	0	/* micro v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION		281070	/* latest targeted hw */
 
+/*  Config is enabled for functional safety: */
+#define XCHAL_HAVE_FUNC_SAFETY		0
+
+/*  Config is enabled for secure operation: */
+#define XCHAL_HAVE_SECURE     		0
+
+#define XCHAL_HAVE_APB			0 
 
 /*----------------------------------------------------------------------
 				CACHE
@@ -244,21 +294,47 @@
 #define XCHAL_DCACHE_LINEWIDTH		6	/* log2(D line size in bytes) */
 
 #define XCHAL_ICACHE_SIZE		16384	/* I-cache size in bytes or 0 */
+#define XCHAL_ICACHE_SIZE_LOG2		14
 #define XCHAL_DCACHE_SIZE		49152	/* D-cache size in bytes or 0 */
+#define XCHAL_DCACHE_SIZE_LOG2		15
 
 #define XCHAL_DCACHE_IS_WRITEBACK	1	/* writeback feature */
 #define XCHAL_DCACHE_IS_COHERENT	0	/* MP coherence feature */
 
 #define XCHAL_HAVE_PREFETCH		1	/* PREFCTL register */
-#define XCHAL_HAVE_PREFETCH_L1		1	/* prefetch to L1 dcache */
+#define XCHAL_HAVE_PREFETCH_L1		1	/* prefetch to L1 cache */
 #define XCHAL_PREFETCH_CASTOUT_LINES	2	/* dcache pref. castout bufsz */
 #define XCHAL_PREFETCH_ENTRIES		8	/* cache prefetch entries */
 #define XCHAL_PREFETCH_BLOCK_ENTRIES	0	/* prefetch block streams */
 #define XCHAL_HAVE_CACHE_BLOCKOPS	0	/* block prefetch for caches */
+#define XCHAL_HAVE_CME_DOWNGRADES	0
 #define XCHAL_HAVE_ICACHE_TEST		1	/* Icache test instructions */
 #define XCHAL_HAVE_DCACHE_TEST		1	/* Dcache test instructions */
 #define XCHAL_HAVE_ICACHE_DYN_WAYS	1	/* Icache dynamic way support */
 #define XCHAL_HAVE_DCACHE_DYN_WAYS	1	/* Dcache dynamic way support */
+#define XCHAL_HAVE_ICACHE_DYN_ENABLE	1	/* Icache enabled via MEMCTL */
+#define XCHAL_HAVE_DCACHE_DYN_ENABLE	1	/* Dcache enabled via MEMCTL */
+
+#define XCHAL_L1SCACHE_SIZE		0
+#define XCHAL_L1SCACHE_SIZE_LOG2	0
+#define XCHAL_L1SCACHE_WAYS		1
+#define XCHAL_L1SCACHE_WAYS_LOG2	0
+#define XCHAL_L1SCACHE_ACCESS_SIZE	0
+#define XCHAL_L1SCACHE_BANKS		1
+
+#define XCHAL_L1VCACHE_SIZE		0
+
+#define XCHAL_HAVE_L2			0	/* NX L2 cache controller */
+#define XCHAL_HAVE_L2_CACHE		0
+#define XCHAL_NUM_CORES_IN_CLUSTER	0
+
+/* PRID_ID macros are for internal use only ... subject to removal */
+#define PRID_ID_SHIFT           0
+#define PRID_ID_BITS            4
+#define PRID_ID_MASK            0x0000000F
+
+/*  This one is a form of caching, though not architecturally visible:  */
+#define XCHAL_HAVE_BRANCH_PREDICTION	0	/* branch [target] prediction */
 
 
 
@@ -291,7 +367,9 @@
 
 /*  Cache set associativity (number of ways):  */
 #define XCHAL_ICACHE_WAYS		2
+#define XCHAL_ICACHE_WAYS_LOG2		1
 #define XCHAL_DCACHE_WAYS		3
+#define XCHAL_DCACHE_WAYS_LOG2		1
 
 /*  Cache features:  */
 #define XCHAL_ICACHE_LINE_LOCKABLE	1
@@ -307,8 +385,14 @@
 
 #define XCHAL_DCACHE_BANKS		2	/* number of banks */
 
+/* The number of Cache lines associated with a single cache tag */
+#define XCHAL_DCACHE_LINES_PER_TAG_LOG2	0
+
 /*  Number of encoded cache attr bits (see <xtensa/hal.h> for decoded bits):  */
 #define XCHAL_CA_BITS			4
+
+/*  Extended memory attributes supported.  */
+#define XCHAL_HAVE_EXT_CA		0
 
 
 /*----------------------------------------------------------------------
@@ -320,6 +404,8 @@
 #define XCHAL_NUM_DATARAM		1	/* number of core data RAMs */
 #define XCHAL_NUM_URAM			0	/* number of core unified RAMs*/
 #define XCHAL_NUM_XLMI			0	/* number of core XLMI ports */
+#define	XCHAL_HAVE_IRAMCFG		0	/* IRAMxCFG register present */
+#define	XCHAL_HAVE_DRAMCFG		0	/* DRAMxCFG register present */
 
 /*  Instruction RAM 0:  */
 #define XCHAL_INSTRAM0_VADDR		0x1FF00000	/* virtual address */
@@ -338,10 +424,15 @@
 #define XCHAL_HAVE_DATARAM0		1
 #define XCHAL_DATARAM0_HAVE_IDMA	0	/* idma supported by this local memory */
 
-#define XCHAL_HAVE_IDMA			0
-#define XCHAL_HAVE_IDMA_TRANSPOSE	0
-
 #define XCHAL_HAVE_IMEM_LOADSTORE	1	/* can load/store to IROM/IRAM*/
+
+
+/*----------------------------------------------------------------------
+			IDMA
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_IDMA			0
+
 
 
 /*----------------------------------------------------------------------
@@ -349,7 +440,6 @@
   ----------------------------------------------------------------------*/
 
 #define XCHAL_HAVE_INTERRUPTS		1	/* interrupt option */
-#define XCHAL_HAVE_HIGHPRI_INTERRUPTS	1	/* med/high-pri. interrupts */
 #define XCHAL_HAVE_NMI			1	/* non-maskable interrupt */
 #define XCHAL_HAVE_CCOUNT		1	/* CCOUNT reg. (timer option) */
 #define XCHAL_NUM_TIMERS		1	/* number of CCOMPAREn regs */
@@ -358,6 +448,9 @@
 #define XCHAL_NUM_EXTINTERRUPTS		4	/* num of external interrupts */
 #define XCHAL_NUM_INTLEVELS		4	/* number of interrupt levels
 						   (not including level zero) */
+
+
+#define XCHAL_HAVE_HIGHPRI_INTERRUPTS	1   /* med/high-pri. interrupts */
 #define XCHAL_EXCM_LEVEL		3	/* level masked by PS.EXCM */
 	/* (always 1 in XEA1; levels 2 .. EXCM_LEVEL are "medium priority") */
 
@@ -407,16 +500,25 @@
 
 /*  Masks of interrupts for each type of interrupt:  */
 #define XCHAL_INTTYPE_MASK_UNCONFIGURED	0xFFFFFE00
-#define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000025
-#define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x00000000
 #define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x00000052
-#define XCHAL_INTTYPE_MASK_TIMER	0x00000008
+#define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x00000000
 #define XCHAL_INTTYPE_MASK_NMI		0x00000100
+#define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000025
+#define XCHAL_INTTYPE_MASK_TIMER	0x00000008
+#define XCHAL_INTTYPE_MASK_ETIE		0x00000000
 #define XCHAL_INTTYPE_MASK_WRITE_ERROR	0x00000000
+#define XCHAL_INTTYPE_MASK_DBG_REQUEST	0x00000000
+#define XCHAL_INTTYPE_MASK_BREAKIN	0x00000000
+#define XCHAL_INTTYPE_MASK_TRAX		0x00000000
 #define XCHAL_INTTYPE_MASK_PROFILING	0x00000080
 #define XCHAL_INTTYPE_MASK_IDMA_DONE	0x00000000
 #define XCHAL_INTTYPE_MASK_IDMA_ERR	0x00000000
 #define XCHAL_INTTYPE_MASK_GS_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_L2_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_L2_STATUS	0x00000000
+#define XCHAL_INTTYPE_MASK_COR_ECC_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_WWDT		0x00000000
+#define XCHAL_INTTYPE_MASK_FXLK		0x00000000
 
 /*  Interrupt numbers assigned to specific interrupt sources:  */
 #define XCHAL_TIMER0_INTERRUPT		3	/* CCOMPARE0 */
@@ -451,19 +553,32 @@
 #define XCHAL_INT6_EXTNUM		2	/* (intlevel 3) */
 #define XCHAL_INT8_EXTNUM		3	/* (intlevel 5) */
 
+#define	XCHAL_HAVE_ISB			0	/* No ISB */
+#define	XCHAL_ISB_VADDR			0	/* N/A    */
+#define	XCHAL_HAVE_ITB			0	/* No ITB */
+#define	XCHAL_ITB_VADDR			0	/* N/A    */
+
+#define	XCHAL_HAVE_KSL			0	/* Kernel Stack Limit */
+#define	XCHAL_HAVE_ISL			0	/* Interrupt Stack Limit */
+#define	XCHAL_HAVE_PSL			0	/* Pageable Stack Limit */
+
 
 /*----------------------------------------------------------------------
 			EXCEPTIONS and VECTORS
   ----------------------------------------------------------------------*/
 
 #define XCHAL_XEA_VERSION		2	/* Xtensa Exception Architecture
-						   number: 1 == XEA1 (old)
-							   2 == XEA2 (new)
-							   0 == XEAX (extern) or TX */
+						   number: 1 == XEA1 (until T1050)
+							   2 == XEA2 (LX)
+							   3 == XEA3 (NX)
+							   0 == XEA5 (RNX) */
 #define XCHAL_HAVE_XEA1			0	/* Exception Architecture 1 */
 #define XCHAL_HAVE_XEA2			1	/* Exception Architecture 2 */
-#define XCHAL_HAVE_XEAX			0	/* External Exception Arch. */
+#define XCHAL_HAVE_XEA3			0	/* Exception Architecture 3 */
+#define XCHAL_HAVE_XEA5			0	/* Exception Architecture 5 */
 #define XCHAL_HAVE_EXCEPTIONS		1	/* exception option */
+#define XCHAL_HAVE_IMPRECISE_EXCEPTIONS	0	/* imprecise exception option */
+#define	XCHAL_EXCCAUSE_NUM		64	/* Number of exceptions */
 #define XCHAL_HAVE_HALT			0	/* halt architecture option */
 #define XCHAL_HAVE_BOOTLOADER		0	/* boot loader (for TX) */
 #define XCHAL_HAVE_MEM_ECC_PARITY	0	/* local memory ECC/parity */
@@ -471,14 +586,14 @@
 #define XCHAL_HAVE_VECBASE		1	/* relocatable vectors */
 #define XCHAL_VECBASE_RESET_VADDR	0x1FF80800  /* VECBASE reset value */
 #define XCHAL_VECBASE_RESET_PADDR	0x1FF80800
-#define XCHAL_RESET_VECBASE_OVERLAP	0
+#define XCHAL_RESET_VECBASE_OVERLAP	0	/* UNUSED */
 
 #define XCHAL_RESET_VECTOR0_VADDR	0x1FF80000
 #define XCHAL_RESET_VECTOR0_PADDR	0x1FF80000
 #define XCHAL_RESET_VECTOR1_VADDR	0x1FF00000
 #define XCHAL_RESET_VECTOR1_PADDR	0x1FF00000
-#define XCHAL_RESET_VECTOR_VADDR	0x1FF80000
-#define XCHAL_RESET_VECTOR_PADDR	0x1FF80000
+#define XCHAL_RESET_VECTOR_VADDR	XCHAL_RESET_VECTOR0_VADDR
+#define XCHAL_RESET_VECTOR_PADDR	XCHAL_RESET_VECTOR0_PADDR
 #define XCHAL_USER_VECOFS		0x00000340
 #define XCHAL_USER_VECTOR_VADDR		0x1FF80B40
 #define XCHAL_USER_VECTOR_PADDR		0x1FF80B40
@@ -571,6 +686,7 @@
   ----------------------------------------------------------------------*/
 #define XCHAL_HAVE_MPU			0 
 #define XCHAL_MPU_ENTRIES		0
+#define XCHAL_MPU_LOCK			0
 
 #define XCHAL_MPU_ALIGN_REQ		1	/* MPU requires alignment of entries to background map */
 #define XCHAL_MPU_BACKGROUND_ENTRIES	0	/* number of entries in bg map*/
@@ -579,8 +695,24 @@
 #define XCHAL_MPU_ALIGN_BITS		0
 #define XCHAL_MPU_ALIGN			0
 
+/*-----------------------------------------------------------------------
+				CSR Parity
+------------------------------------------------------------------------*/
+#define XCHAL_HAVE_CSR_PARITY		0
+
+
+/*----------------------------------------------------------------------
+				FLEX-LOCK
+------------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_FXLK			0
+
+/*----------------------------------------------------------------------
+				WWDT (Windowed Watchdog Timer)
+------------------------------------------------------------------------*/
+#define XCHAL_HAVE_WWDT			0
 #endif /* !XTENSA_HAL_NON_PRIVILEGED_ONLY */
 
 
-#endif /* _XTENSA_CORE_CONFIGURATION_H */
+#endif /* XTENSA_CORE_CONFIGURATION_H_ */
 

--- a/zephyr/soc/intel_ace15_mtpm/xtensa/config/core-matmap.h
+++ b/zephyr/soc/intel_ace15_mtpm/xtensa/config/core-matmap.h
@@ -22,7 +22,7 @@
  *	XCHAL_HW_VERSION_MINOR
  */
 
-/* Customer ID=10631; Build=0x863b0; Copyright (c) 1999-2019 Tensilica Inc.
+/* Copyright (c) 1999-2022 Tensilica Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -104,6 +104,7 @@
 				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
 				XTHAL_SAM_EXCEPTION
 
+/*  The following defines are deprecated. DO NOT USE.  */
 #define XCHAL_CA_R   (0xC0 | 0x40000000)
 #define XCHAL_CA_RX  (0xD0 | 0x40000000)
 #define XCHAL_CA_RW  (0xE0 | 0x40000000)

--- a/zephyr/soc/intel_ace15_mtpm/xtensa/config/specreg.h
+++ b/zephyr/soc/intel_ace15_mtpm/xtensa/config/specreg.h
@@ -2,9 +2,9 @@
  * Xtensa Special Register symbolic names
  */
 
-/* $Id: //depot/rel/Foxhill/dot.12/Xtensa/SWConfig/hal/specreg.h.tpp#1 $ */
+/* $Id: //depot/rel/Homewood/ib.10/Xtensa/SWConfig/hal/specreg.h.tpp#1 $ */
 
-/* Customer ID=10631; Build=0x863b0; Copyright (c) 1998-2002 Tensilica Inc.
+/* Copyright (c) 1998-2002 Tensilica Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -80,6 +80,7 @@
 #define ICOUNTLEVEL	237
 #define EXCVADDR	238
 #define CCOMPARE_0	240
+
 
 /*  Special cases (bases of special register series):  */
 #define IBREAKA		128

--- a/zephyr/soc/intel_ace15_mtpm/xtensa/config/system.h
+++ b/zephyr/soc/intel_ace15_mtpm/xtensa/config/system.h
@@ -10,7 +10,7 @@
  *  core-specific but system independent.
  */
 
-/* Customer ID=10631; Build=0x863b0; Copyright (c) 2000-2010 Tensilica Inc.
+/* Copyright (c) 2000-2010 Tensilica Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -35,9 +35,6 @@
 #ifndef XTENSA_CONFIG_SYSTEM_H
 #define XTENSA_CONFIG_SYSTEM_H
 
-/*#include <xtensa/hal.h>*/
-
-
 
 /*----------------------------------------------------------------------
 				CONFIGURED SOFTWARE OPTIONS
@@ -50,28 +47,18 @@
 /*  The above maps to one of the following constants:  */
 #define XTHAL_ABI_WINDOWED		0
 #define XTHAL_ABI_CALL0			1
-/*  Alternatives:  */
-/*#define XSHAL_WINDOWED_ABI		1*/	/* set if windowed ABI selected */
-/*#define XSHAL_CALL0_ABI		0*/	/* set if call0 ABI selected */
 
 #define XSHAL_CLIB			XTHAL_CLIB_NEWLIB	/* (sw-only option, selected C library) */
 /*  The above maps to one of the following constants:  */
 #define XTHAL_CLIB_NEWLIB		0
 #define XTHAL_CLIB_UCLIBC		1
 #define XTHAL_CLIB_XCLIB		2
-/*  Alternatives:  */
-/*#define XSHAL_NEWLIB			1*/	/* set if newlib C library selected */
-/*#define XSHAL_UCLIBC			0*/	/* set if uCLibC C library selected */
-/*#define XSHAL_XCLIB			0*/	/* set if Xtensa C library selected */
 
 #define XSHAL_USE_FLOATING_POINT	1
 
-#define XSHAL_FLOATING_POINT_ABI	1
+#define XSHAL_FLOATING_POINT_ABI        1
 
 /*  SW workarounds enabled for HW errata:  */
-
-/*  SW options for functional safety:  */
-#define XSHAL_FUNC_SAFETY_ENABLED	0
 
 /*----------------------------------------------------------------------
 				DEVICE ADDRESSES
@@ -89,8 +76,8 @@
 #define XSHAL_IOBLOCK_CACHED_PADDR	0x70000000
 #define XSHAL_IOBLOCK_CACHED_SIZE	0x0E000000
 
-#define XSHAL_IOBLOCK_BYPASS_VADDR	0x50000000
-#define XSHAL_IOBLOCK_BYPASS_PADDR	0x50000000
+#define XSHAL_IOBLOCK_BYPASS_VADDR	0x90000000
+#define XSHAL_IOBLOCK_BYPASS_PADDR	0x90000000
 #define XSHAL_IOBLOCK_BYPASS_SIZE	0x0E000000
 
 /*  System ROM:  */
@@ -125,8 +112,6 @@
 #define XSHAL_RAM_BYPASS_PSIZE		0x01000000
 
 /*  Alternate system RAM (different device than system RAM):  */
-/*#define XSHAL_ALTRAM_[VP]ADDR		...not configured...*/
-/*#define XSHAL_ALTRAM_SIZE		...not configured...*/
 
 /*  Some available location in which to place devices in a simulation (eg. XTMP):  */
 #define XSHAL_SIMIO_CACHED_VADDR	0xC0000000
@@ -139,6 +124,7 @@
  *  For use by reference testbench exit and diagnostic routines.
  */
 #define XSHAL_MAGIC_EXIT		0xc0000000
+#define XSHAL_STL_INFO_LOCATION		0x3ffffffc
 
 /*----------------------------------------------------------------------
  *			DEVICE-ADDRESS DEPENDENT...
@@ -214,10 +200,10 @@
  *  of whether the macro is _WRITEBACK vs. _BYPASS etc.  */
 
 /*  These set any 512MB region unused on the XT2000 to ILLEGAL attribute:  */
-#define XSHAL_XT2000_CACHEATTR_WRITEBACK	0x4F4F4224	/* enable caches in write-back mode */
-#define XSHAL_XT2000_CACHEATTR_WRITEALLOC	0x1F1F1221	/* enable caches in write-allocate mode */
-#define XSHAL_XT2000_CACHEATTR_WRITETHRU	0x1F1F1221	/* enable caches in write-through mode */
-#define XSHAL_XT2000_CACHEATTR_BYPASS		0x2F2F2222	/* disable caches in bypass mode */
+#define XSHAL_XT2000_CACHEATTR_WRITEBACK	0x4F424F24	/* enable caches in write-back mode */
+#define XSHAL_XT2000_CACHEATTR_WRITEALLOC	0x1F121F21	/* enable caches in write-allocate mode */
+#define XSHAL_XT2000_CACHEATTR_WRITETHRU	0x1F121F21	/* enable caches in write-through mode */
+#define XSHAL_XT2000_CACHEATTR_BYPASS		0x2F222F22	/* disable caches in bypass mode */
 #define XSHAL_XT2000_CACHEATTR_DEFAULT		XSHAL_XT2000_CACHEATTR_WRITEBACK	/* default setting to enable caches */
 
 #define XSHAL_XT2000_PIPE_REGIONS	0x00000000	/* BusInt pipeline regions */
@@ -228,7 +214,7 @@
 				VECTOR INFO AND SIZES
   ----------------------------------------------------------------------*/
 
-#define XSHAL_VECTORS_PACKED		0
+#define XSHAL_VECTORS_PACKED		0	/* UNUSED */
 #define XSHAL_STATIC_VECTOR_SELECT	0
 #define XSHAL_RESET_VECTOR_VADDR	0x1FF80000
 #define XSHAL_RESET_VECTOR_PADDR	0x1FF80000
@@ -267,7 +253,6 @@
 #define XSHAL_NMI_VECTOR_SIZE	0x00000038
 #define XSHAL_NMI_VECTOR_ISROM	0
 #define XSHAL_INTLEVEL5_VECTOR_SIZE	XSHAL_NMI_VECTOR_SIZE
-
 
 #endif /*XTENSA_CONFIG_SYSTEM_H*/
 

--- a/zephyr/soc/intel_ace15_mtpm/xtensa/config/tie-asm.h
+++ b/zephyr/soc/intel_ace15_mtpm/xtensa/config/tie-asm.h
@@ -1,4 +1,4 @@
-/*
+/* 
  * tie-asm.h -- compile-time HAL assembler definitions dependent on CORE & TIE
  *
  *  NOTE:  This header file is not meant to be included directly.
@@ -8,7 +8,7 @@
    macros, etc.) for this specific Xtensa processor's TIE extensions
    and options.  It is customized to this Xtensa processor configuration.
 
-   Copyright (c) 1999-2018 Cadence Design Systems Inc.
+   Copyright (c) 1999-2022 Cadence Design Systems Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -29,10 +29,10 @@
    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#if !defined __XCC__
-
 #ifndef _XTENSA_CORE_TIE_ASM_H
 #define _XTENSA_CORE_TIE_ASM_H
+
+#include <xtensa/coreasm.h>
 
 /*  Selection parameter values for save-area save/restore macros:  */
 /*  Option vs. TIE:  */
@@ -80,7 +80,7 @@
 	// Optional global registers used by default by the compiler:
 	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\select)
 	xchal_sa_align	\ptr, 0, 1016, 4, 4
-	rur.THREADPTR	\at1		// threadptr option
+	rur.threadptr	\at1		// threadptr option
 	s32i	\at1, \ptr, .Lxchal_ofs_+0
 	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
 	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\alloc)) == 0
@@ -90,9 +90,9 @@
 	// Optional caller-saved registers not used by default by the compiler:
 	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
 	xchal_sa_align	\ptr, 0, 1012, 4, 4
-	rsr.BR	\at1		// boolean option
+	rsr.br	\at1		// boolean option
 	s32i	\at1, \ptr, .Lxchal_ofs_+0
-	rsr.SCOMPARE1	\at1		// conditional store option
+	rsr.scompare1	\at1		// conditional store option
 	s32i	\at1, \ptr, .Lxchal_ofs_+4
 	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
 	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
@@ -127,7 +127,7 @@
 	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\select)
 	xchal_sa_align	\ptr, 0, 1016, 4, 4
 	l32i	\at1, \ptr, .Lxchal_ofs_+0
-	wur.THREADPTR	\at1		// threadptr option
+	wur.threadptr	\at1		// threadptr option
 	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
 	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\alloc)) == 0
 	xchal_sa_align	\ptr, 0, 1016, 4, 4
@@ -137,9 +137,9 @@
 	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
 	xchal_sa_align	\ptr, 0, 1012, 4, 4
 	l32i	\at1, \ptr, .Lxchal_ofs_+0
-	wsr.BR	\at1		// boolean option
+	wsr.br	\at1		// boolean option
 	l32i	\at1, \ptr, .Lxchal_ofs_+4
-	wsr.SCOMPARE1	\at1		// conditional store option
+	wsr.scompare1	\at1		// conditional store option
 	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
 	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
 	xchal_sa_align	\ptr, 0, 1012, 4, 4
@@ -150,92 +150,7 @@
 
 #define XCHAL_NCP_NUM_ATMPS	1
 
-    /*
-     *  Macro to store the state of TIE coprocessor FPU.
-     *  Required parameters:
-     *      ptr         Save area pointer address register (clobbered)
-     *                  (register must contain a 4 byte aligned address).
-     *      at1..at4    Four temporary address registers (first XCHAL_CP0_NUM_ATMPS
-     *                  registers are clobbered, the remaining are unused).
-     *  Optional parameters are the same as for xchal_ncp_store.
-     */
-#define xchal_cp_FPU_store	xchal_cp0_store
-    .macro	xchal_cp0_store  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
-	xchal_sa_start \continue, \ofs
-	// Custom caller-saved registers not used by default by the compiler:
-	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
-	xchal_sa_align	\ptr, 0, 948, 4, 4
-	rur.FCR	\at1		// ureg 232
-	s32i	\at1, \ptr, .Lxchal_ofs_+0
-	rur.FSR	\at1		// ureg 233
-	s32i	\at1, \ptr, .Lxchal_ofs_+4
-	ssi	f0, \ptr, .Lxchal_ofs_+8
-	ssi	f1, \ptr, .Lxchal_ofs_+12
-	ssi	f2, \ptr, .Lxchal_ofs_+16
-	ssi	f3, \ptr, .Lxchal_ofs_+20
-	ssi	f4, \ptr, .Lxchal_ofs_+24
-	ssi	f5, \ptr, .Lxchal_ofs_+28
-	ssi	f6, \ptr, .Lxchal_ofs_+32
-	ssi	f7, \ptr, .Lxchal_ofs_+36
-	ssi	f8, \ptr, .Lxchal_ofs_+40
-	ssi	f9, \ptr, .Lxchal_ofs_+44
-	ssi	f10, \ptr, .Lxchal_ofs_+48
-	ssi	f11, \ptr, .Lxchal_ofs_+52
-	ssi	f12, \ptr, .Lxchal_ofs_+56
-	ssi	f13, \ptr, .Lxchal_ofs_+60
-	ssi	f14, \ptr, .Lxchal_ofs_+64
-	ssi	f15, \ptr, .Lxchal_ofs_+68
-	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 72
-	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
-	xchal_sa_align	\ptr, 0, 948, 4, 4
-	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 72
-	.endif
-    .endm	// xchal_cp0_store
-
-    /*
-     *  Macro to load the state of TIE coprocessor FPU.
-     *  Required parameters:
-     *      ptr         Save area pointer address register (clobbered)
-     *                  (register must contain a 4 byte aligned address).
-     *      at1..at4    Four temporary address registers (first XCHAL_CP0_NUM_ATMPS
-     *                  registers are clobbered, the remaining are unused).
-     *  Optional parameters are the same as for xchal_ncp_load.
-     */
-#define xchal_cp_FPU_load	xchal_cp0_load
-    .macro	xchal_cp0_load  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
-	xchal_sa_start \continue, \ofs
-	// Custom caller-saved registers not used by default by the compiler:
-	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
-	xchal_sa_align	\ptr, 0, 948, 4, 4
-	l32i	\at1, \ptr, .Lxchal_ofs_+0
-	wur.FCR	\at1		// ureg 232
-	l32i	\at1, \ptr, .Lxchal_ofs_+4
-	wur.FSR	\at1		// ureg 233
-	lsi	f0, \ptr, .Lxchal_ofs_+8
-	lsi	f1, \ptr, .Lxchal_ofs_+12
-	lsi	f2, \ptr, .Lxchal_ofs_+16
-	lsi	f3, \ptr, .Lxchal_ofs_+20
-	lsi	f4, \ptr, .Lxchal_ofs_+24
-	lsi	f5, \ptr, .Lxchal_ofs_+28
-	lsi	f6, \ptr, .Lxchal_ofs_+32
-	lsi	f7, \ptr, .Lxchal_ofs_+36
-	lsi	f8, \ptr, .Lxchal_ofs_+40
-	lsi	f9, \ptr, .Lxchal_ofs_+44
-	lsi	f10, \ptr, .Lxchal_ofs_+48
-	lsi	f11, \ptr, .Lxchal_ofs_+52
-	lsi	f12, \ptr, .Lxchal_ofs_+56
-	lsi	f13, \ptr, .Lxchal_ofs_+60
-	lsi	f14, \ptr, .Lxchal_ofs_+64
-	lsi	f15, \ptr, .Lxchal_ofs_+68
-	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 72
-	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
-	xchal_sa_align	\ptr, 0, 948, 4, 4
-	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 72
-	.endif
-    .endm	// xchal_cp0_load
-
-#define XCHAL_CP0_NUM_ATMPS	1
-    /*
+    /* 
      *  Macro to store the state of TIE coprocessor AudioEngineLX.
      *  Required parameters:
      *      ptr         Save area pointer address register (clobbered)
@@ -250,49 +165,64 @@
 	// Custom caller-saved registers not used by default by the compiler:
 	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
 	xchal_sa_align	\ptr, 0, 0, 8, 8
-	rur.AE_OVF_SAR	\at1		// ureg 240
-	s32i	\at1, \ptr, .Lxchal_ofs_+0
-	rur.AE_BITHEAD	\at1		// ureg 241
-	s32i	\at1, \ptr, .Lxchal_ofs_+4
-	rur.AE_TS_FTS_BU_BP	\at1		// ureg 242
+	ae_s64.i	aed0, \ptr, .Lxchal_ofs_+40
+	ae_s64.i	aed1, \ptr, .Lxchal_ofs_+48
+	ae_s64.i	aed2, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_s64.i	aed3, \ptr, .Lxchal_ofs_+0
+	ae_s64.i	aed4, \ptr, .Lxchal_ofs_+8
+	ae_s64.i	aed5, \ptr, .Lxchal_ofs_+16
+	ae_s64.i	aed6, \ptr, .Lxchal_ofs_+24
+	ae_s64.i	aed7, \ptr, .Lxchal_ofs_+32
+	ae_s64.i	aed8, \ptr, .Lxchal_ofs_+40
+	ae_s64.i	aed9, \ptr, .Lxchal_ofs_+48
+	ae_s64.i	aed10, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_s64.i	aed11, \ptr, .Lxchal_ofs_+0
+	ae_s64.i	aed12, \ptr, .Lxchal_ofs_+8
+	ae_s64.i	aed13, \ptr, .Lxchal_ofs_+16
+	ae_s64.i	aed14, \ptr, .Lxchal_ofs_+24
+	ae_s64.i	aed15, \ptr, .Lxchal_ofs_+32
+	ae_movae	\at1, aep0
+	s8i	\at1, \ptr, .Lxchal_ofs_+40
+	ae_movae	\at1, aep1
+	s8i	\at1, \ptr, .Lxchal_ofs_+41
+	ae_movae	\at1, aep2
+	s8i	\at1, \ptr, .Lxchal_ofs_+42
+	ae_movae	\at1, aep3
+	s8i	\at1, \ptr, .Lxchal_ofs_+43
+	ae_salign64.i	u0, \ptr, .Lxchal_ofs_+48
+	ae_salign64.i	u1, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_salign64.i	u2, \ptr, .Lxchal_ofs_+0
+	ae_salign64.i	u3, \ptr, .Lxchal_ofs_+8
+	addi	\ptr, \ptr, -192
+	ae_movvfcrfsr	aed0		// ureg FCR_FSR
+	ae_s64.i	aed0, \ptr, .Lxchal_ofs_+0 + 0
+	rur.ae_ovf_sar	\at1		// ureg 240
 	s32i	\at1, \ptr, .Lxchal_ofs_+8
-	rur.AE_CW_SD_NO	\at1		// ureg 243
+	rur.ae_bithead	\at1		// ureg 241
 	s32i	\at1, \ptr, .Lxchal_ofs_+12
-	rur.AE_CBEGIN0	\at1		// ureg 246
+	rur.ae_ts_fts_bu_bp	\at1		// ureg 242
 	s32i	\at1, \ptr, .Lxchal_ofs_+16
-	rur.AE_CEND0	\at1		// ureg 247
+	rur.ae_cw_sd_no	\at1		// ureg 243
 	s32i	\at1, \ptr, .Lxchal_ofs_+20
-	ae_s64.i	aed0, \ptr, .Lxchal_ofs_+24
-	ae_s64.i	aed1, \ptr, .Lxchal_ofs_+32
-	ae_s64.i	aed2, \ptr, .Lxchal_ofs_+40
-	ae_s64.i	aed3, \ptr, .Lxchal_ofs_+48
-	ae_s64.i	aed4, \ptr, .Lxchal_ofs_+56
-	addi	\ptr, \ptr, 64
-	ae_s64.i	aed5, \ptr, .Lxchal_ofs_+0
-	ae_s64.i	aed6, \ptr, .Lxchal_ofs_+8
-	ae_s64.i	aed7, \ptr, .Lxchal_ofs_+16
-	ae_s64.i	aed8, \ptr, .Lxchal_ofs_+24
-	ae_s64.i	aed9, \ptr, .Lxchal_ofs_+32
-	ae_s64.i	aed10, \ptr, .Lxchal_ofs_+40
-	ae_s64.i	aed11, \ptr, .Lxchal_ofs_+48
-	ae_s64.i	aed12, \ptr, .Lxchal_ofs_+56
-	addi	\ptr, \ptr, 64
-	ae_s64.i	aed13, \ptr, .Lxchal_ofs_+0
-	ae_s64.i	aed14, \ptr, .Lxchal_ofs_+8
-	ae_s64.i	aed15, \ptr, .Lxchal_ofs_+16
-	ae_salign64.i	u0, \ptr, .Lxchal_ofs_+24
-	ae_salign64.i	u1, \ptr, .Lxchal_ofs_+32
-	ae_salign64.i	u2, \ptr, .Lxchal_ofs_+40
-	ae_salign64.i	u3, \ptr, .Lxchal_ofs_+48
-	.set	.Lxchal_pofs_, .Lxchal_pofs_ + 128
-	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 56
+	rur.ae_cbegin0	\at1		// ureg 246
+	s32i	\at1, \ptr, .Lxchal_ofs_+24
+	rur.ae_cend0	\at1		// ureg 247
+	s32i	\at1, \ptr, .Lxchal_ofs_+28
+	rur.ae_cbegin1	\at1		// ureg 248
+	s32i	\at1, \ptr, .Lxchal_ofs_+32
+	rur.ae_cend1	\at1		// ureg 249
+	s32i	\at1, \ptr, .Lxchal_ofs_+36
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
 	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
 	xchal_sa_align	\ptr, 0, 0, 8, 8
-	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 184
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
 	.endif
     .endm	// xchal_cp1_store
 
-    /*
+    /* 
      *  Macro to load the state of TIE coprocessor AudioEngineLX.
      *  Required parameters:
      *      ptr         Save area pointer address register (clobbered)
@@ -307,46 +237,61 @@
 	// Custom caller-saved registers not used by default by the compiler:
 	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
 	xchal_sa_align	\ptr, 0, 0, 8, 8
-	l32i	\at1, \ptr, .Lxchal_ofs_+0
-	wur.AE_OVF_SAR	\at1		// ureg 240
-	l32i	\at1, \ptr, .Lxchal_ofs_+4
-	wur.AE_BITHEAD	\at1		// ureg 241
+	ae_l64.i	aed0, \ptr, .Lxchal_ofs_+0 + 0		// ureg FCR_FSR
+	ae_movfcrfsrv	aed0
 	l32i	\at1, \ptr, .Lxchal_ofs_+8
-	wur.AE_TS_FTS_BU_BP	\at1		// ureg 242
+	wur.ae_ovf_sar	\at1		// ureg 240
 	l32i	\at1, \ptr, .Lxchal_ofs_+12
-	wur.AE_CW_SD_NO	\at1		// ureg 243
+	wur.ae_bithead	\at1		// ureg 241
 	l32i	\at1, \ptr, .Lxchal_ofs_+16
-	wur.AE_CBEGIN0	\at1		// ureg 246
+	wur.ae_ts_fts_bu_bp	\at1		// ureg 242
 	l32i	\at1, \ptr, .Lxchal_ofs_+20
-	wur.AE_CEND0	\at1		// ureg 247
-	ae_l64.i	aed0, \ptr, .Lxchal_ofs_+24
-	ae_l64.i	aed1, \ptr, .Lxchal_ofs_+32
-	ae_l64.i	aed2, \ptr, .Lxchal_ofs_+40
-	ae_l64.i	aed3, \ptr, .Lxchal_ofs_+48
-	ae_l64.i	aed4, \ptr, .Lxchal_ofs_+56
+	wur.ae_cw_sd_no	\at1		// ureg 243
+	l32i	\at1, \ptr, .Lxchal_ofs_+24
+	wur.ae_cbegin0	\at1		// ureg 246
+	l32i	\at1, \ptr, .Lxchal_ofs_+28
+	wur.ae_cend0	\at1		// ureg 247
+	l32i	\at1, \ptr, .Lxchal_ofs_+32
+	wur.ae_cbegin1	\at1		// ureg 248
+	l32i	\at1, \ptr, .Lxchal_ofs_+36
+	wur.ae_cend1	\at1		// ureg 249
+	ae_l64.i	aed0, \ptr, .Lxchal_ofs_+40
+	ae_l64.i	aed1, \ptr, .Lxchal_ofs_+48
+	ae_l64.i	aed2, \ptr, .Lxchal_ofs_+56
 	addi	\ptr, \ptr, 64
-	ae_l64.i	aed5, \ptr, .Lxchal_ofs_+0
-	ae_l64.i	aed6, \ptr, .Lxchal_ofs_+8
-	ae_l64.i	aed7, \ptr, .Lxchal_ofs_+16
-	ae_l64.i	aed8, \ptr, .Lxchal_ofs_+24
-	ae_l64.i	aed9, \ptr, .Lxchal_ofs_+32
-	ae_l64.i	aed10, \ptr, .Lxchal_ofs_+40
-	ae_l64.i	aed11, \ptr, .Lxchal_ofs_+48
-	ae_l64.i	aed12, \ptr, .Lxchal_ofs_+56
+	ae_l64.i	aed3, \ptr, .Lxchal_ofs_+0
+	ae_l64.i	aed4, \ptr, .Lxchal_ofs_+8
+	ae_l64.i	aed5, \ptr, .Lxchal_ofs_+16
+	ae_l64.i	aed6, \ptr, .Lxchal_ofs_+24
+	ae_l64.i	aed7, \ptr, .Lxchal_ofs_+32
+	ae_l64.i	aed8, \ptr, .Lxchal_ofs_+40
+	ae_l64.i	aed9, \ptr, .Lxchal_ofs_+48
+	ae_l64.i	aed10, \ptr, .Lxchal_ofs_+56
 	addi	\ptr, \ptr, 64
-	ae_l64.i	aed13, \ptr, .Lxchal_ofs_+0
-	ae_l64.i	aed14, \ptr, .Lxchal_ofs_+8
-	ae_l64.i	aed15, \ptr, .Lxchal_ofs_+16
-	addi	\ptr, \ptr, 24
+	ae_l64.i	aed11, \ptr, .Lxchal_ofs_+0
+	ae_l64.i	aed12, \ptr, .Lxchal_ofs_+8
+	ae_l64.i	aed13, \ptr, .Lxchal_ofs_+16
+	ae_l64.i	aed14, \ptr, .Lxchal_ofs_+24
+	ae_l64.i	aed15, \ptr, .Lxchal_ofs_+32
+	addi	\ptr, \ptr, 40
+	l8ui	\at1, \ptr, .Lxchal_ofs_+0
+	ae_movea	aep0, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+1
+	ae_movea	aep1, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+2
+	ae_movea	aep2, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+3
+	ae_movea	aep3, \at1
+	addi	\ptr, \ptr, 8
 	ae_lalign64.i	u0, \ptr, .Lxchal_ofs_+0
 	ae_lalign64.i	u1, \ptr, .Lxchal_ofs_+8
 	ae_lalign64.i	u2, \ptr, .Lxchal_ofs_+16
 	ae_lalign64.i	u3, \ptr, .Lxchal_ofs_+24
-	.set	.Lxchal_pofs_, .Lxchal_pofs_ + 152
+	.set	.Lxchal_pofs_, .Lxchal_pofs_ + 176
 	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 32
 	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
 	xchal_sa_align	\ptr, 0, 0, 8, 8
-	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 184
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
 	.endif
     .endm	// xchal_cp1_load
 
@@ -354,6 +299,8 @@
 #define XCHAL_SA_NUM_ATMPS	1
 
 	/*  Empty macros for unconfigured coprocessors:  */
+	.macro xchal_cp0_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp0_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
 	.macro xchal_cp2_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
 	.macro xchal_cp2_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
 	.macro xchal_cp3_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
@@ -369,8 +316,3 @@
 
 #endif /*_XTENSA_CORE_TIE_ASM_H*/
 
-#else
-
-#error "xcc should not use this header"
-
-#endif /* __XCC__ */

--- a/zephyr/soc/intel_ace15_mtpm/xtensa/config/tie.h
+++ b/zephyr/soc/intel_ace15_mtpm/xtensa/config/tie.h
@@ -8,7 +8,7 @@
    that extend basic Xtensa core functionality.  It is customized to this
    Xtensa processor configuration.
 
-   Customer ID=10631; Build=0x863b0; Copyright (c) 1999-2019 Cadence Design Systems Inc.
+   Copyright (c) 1999-2022 Cadence Design Systems Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -29,8 +29,10 @@
    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#ifndef _XTENSA_CORE_TIE_H
-#define _XTENSA_CORE_TIE_H
+#ifndef XTENSA_CORE_TIE_H
+#define XTENSA_CORE_TIE_H
+
+/* parasoft-begin-suppress ALL "This file not MISRA checked." */
 
 #define XCHAL_CP_NUM			1	/* number of coprocessors */
 #define XCHAL_CP_MAX			2	/* max CP ID + 1 (0 if none) */
@@ -184,5 +186,7 @@
 	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
 	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11
 
-#endif /*_XTENSA_CORE_TIE_H*/
+/* parasoft-end-suppress ALL "This file not MISRA checked." */
+
+#endif /* XTENSA_CORE_TIE_H */
 


### PR DESCRIPTION
Update the overlay files of intel_ace15_mtpm. The previous ones contained assembly for floating-point coprocessor that cannot be processed correctly by GCC built from the same overlay.