### PR TITLE
zephyr: Add SoC overlay for MIMXRT685 HiFi4 DSP

### DIFF
--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/core-isa.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/core-isa.h
@@ -1,0 +1,813 @@
+/* 
+ * xtensa/config/core-isa.h -- HAL definitions that are dependent on Xtensa
+ *				processor CORE configuration
+ *
+ *  See <xtensa/config/core.h>, which includes this file, for more details.
+ */
+
+/* Xtensa processor core configuration information.
+
+   Copyright (c) 1999-2023 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef XTENSA_CORE_CONFIGURATION_H_
+#define XTENSA_CORE_CONFIGURATION_H_
+
+
+/****************************************************************************
+	    Parameters Useful for Any Code, USER or PRIVILEGED
+ ****************************************************************************/
+
+/*
+ *  Note:  Macros of the form XCHAL_HAVE_*** have a value of 1 if the option is
+ *  configured, and a value of 0 otherwise.  These macros are always defined.
+ */
+
+
+/*----------------------------------------------------------------------
+				ISA
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_BE			0	/* big-endian byte ordering */
+#define XCHAL_HAVE_WINDOWED		1	/* windowed registers option */
+#define XCHAL_NUM_AREGS			32	/* num of physical addr regs */
+#define XCHAL_NUM_AREGS_LOG2		5	/* log2(XCHAL_NUM_AREGS) */
+#define XCHAL_MAX_INSTRUCTION_SIZE	11	/* max instr bytes (3..8) */
+#define XCHAL_HAVE_DEBUG		1	/* debug option */
+#define XCHAL_HAVE_DENSITY		1	/* 16-bit instructions */
+#define XCHAL_HAVE_LOOPS		1	/* zero-overhead loops */
+#define XCHAL_LOOP_BUFFER_SIZE		256	/* zero-ov. loop instr buffer size */
+#define XCHAL_HAVE_NSA			1	/* NSA/NSAU instructions */
+#define XCHAL_HAVE_MINMAX		1	/* MIN/MAX instructions */
+#define XCHAL_HAVE_SEXT			1	/* SEXT instruction */
+#define XCHAL_HAVE_DEPBITS		0	/* DEPBITS instruction */
+#define XCHAL_HAVE_CLAMPS		1	/* CLAMPS instruction */
+#define XCHAL_HAVE_MUL16		1	/* MUL16S/MUL16U instructions */
+#define XCHAL_HAVE_MUL32		1	/* MULL instruction */
+#define XCHAL_HAVE_MUL32_HIGH		1	/* MULUH/MULSH instructions */
+#define XCHAL_HAVE_DIV32		1	/* QUOS/QUOU/REMS/REMU instructions */
+#define XCHAL_HAVE_L32R			1	/* L32R instruction */
+#define XCHAL_HAVE_ABSOLUTE_LITERALS	0	/* non-PC-rel (extended) L32R */
+#define XCHAL_HAVE_CONST16		0	/* CONST16 instruction */
+#define XCHAL_HAVE_ADDX			1	/* ADDX#/SUBX# instructions */
+#define XCHAL_HAVE_EXCLUSIVE            0	/* L32EX/S32EX instructions */
+#define XCHAL_HAVE_WIDE_BRANCHES	0	/* B*.W18 or B*.W15 instr's */
+#define XCHAL_HAVE_PREDICTED_BRANCHES	0	/* B[EQ/EQZ/NE/NEZ]T instr's */
+#define XCHAL_HAVE_CALL4AND12		1	/* (obsolete option) */
+#define XCHAL_HAVE_ABS			1	/* ABS instruction */
+#define XCHAL_HAVE_RELEASE_SYNC		1	/* L32AI/S32RI instructions */
+#define XCHAL_HAVE_S32C1I		1	/* S32C1I instruction */
+#define XCHAL_HAVE_SPECULATION		0	/* speculation */
+#define XCHAL_HAVE_FULL_RESET		1	/* all regs/state reset */
+#define XCHAL_NUM_CONTEXTS		1	/* */
+#define XCHAL_NUM_MISC_REGS		2	/* num of scratch regs (0..4) */
+#define XCHAL_HAVE_TAP_MASTER		0	/* JTAG TAP control instr's */
+#define XCHAL_HAVE_PRID			1	/* processor ID register */
+#define XCHAL_HAVE_EXTERN_REGS		1	/* WER/RER instructions */
+#define XCHAL_HAVE_MX			0	/* MX core (Tensilica internal) */
+#define XCHAL_HAVE_MP_INTERRUPTS	0	/* interrupt distributor port */
+#define XCHAL_HAVE_MP_RUNSTALL		0	/* core RunStall control port */
+#define XCHAL_HAVE_PSO			0	/* Power Shut-Off */
+#define XCHAL_HAVE_PSO_CDM		0	/* core/debug/mem pwr domains */
+#define XCHAL_HAVE_PSO_FULL_RETENTION	0	/* all regs preserved on PSO */
+#define XCHAL_HAVE_THREADPTR		1	/* THREADPTR register */
+#define XCHAL_HAVE_BOOLEANS		1	/* boolean registers */
+#define XCHAL_HAVE_CP			1	/* CPENABLE reg (coprocessor) */
+#define XCHAL_CP_MAXCFG			2	/* max allowed cp id plus one */
+#define XCHAL_HAVE_MAC16		1	/* MAC16 package */
+#define XCHAL_HAVE_LX			1	/* LX core */
+#define XCHAL_HAVE_NX			0	/* NX core (starting RH) */
+#define XCHAL_HAVE_RNX 			0	/* RNX core (starting RJ) */	
+
+#define XCHAL_HAVE_SUPERGATHER		0	/* SuperGather */
+
+#define XCHAL_HAVE_FUSION		0                      /* Fusion */
+#define XCHAL_HAVE_FUSION_FP		0	/* Fusion FP option */
+#define XCHAL_HAVE_FUSION_LOW_POWER	0	/* Fusion Low Power option */
+#define XCHAL_HAVE_FUSION_AES		0	/* Fusion BLE/Wifi AES-128 CCM option */
+#define XCHAL_HAVE_FUSION_CONVENC	0	/* Fusion Conv Encode option */
+#define XCHAL_HAVE_FUSION_LFSR_CRC	0	/* Fusion LFSR-CRC option */
+#define XCHAL_HAVE_FUSION_BITOPS	0	/* Fusion Bit Operations Support option */
+#define XCHAL_HAVE_FUSION_AVS		0	/* Fusion AVS option */
+#define XCHAL_HAVE_FUSION_16BIT_BASEBAND 0	/* Fusion 16-bit Baseband option */
+#define XCHAL_HAVE_FUSION_VITERBI	0	/* Fusion Viterbi option */
+#define XCHAL_HAVE_FUSION_SOFTDEMAP	0	/* Fusion Soft Bit Demap option */
+#define XCHAL_HAVE_HIFIPRO		0	/* HiFiPro Audio Engine pkg */
+#define XCHAL_HAVE_HIFI5		0	/* HiFi5 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI5_NN_MAC		0	/* HiFi5 Audio Engine NN-MAC option */
+#define XCHAL_HAVE_HIFI5_VFPU		0	/* HiFi5 Audio Engine Single-Precision VFPU option */
+#define XCHAL_HAVE_HIFI5_HP_VFPU	0	/* HiFi5 Audio Engine Half-Precision VFPU option */
+#define XCHAL_HAVE_HIFI4		1	/* HiFi4 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI4_VFPU		1	/* HiFi4 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI3		1	/* HiFi3 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI3_VFPU		0	/* HiFi3 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI3Z		0	/* HiFi3Z Audio Engine pkg */
+#define XCHAL_HAVE_HIFI3Z_VFPU	0	/* HiFi3Z Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI1		0	/* HiFi1 */
+#define XCHAL_HAVE_HIFI1_VFPU		0	/* HiFi1 VFPU option */
+#define XCHAL_HAVE_HIFI1_LOW_LATENCY_MAC_FMA		0	/* HiFi1 Low-latency MAC/FMA option */
+#define XCHAL_HAVE_HIFI2		0	/* HiFi2 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI2EP		0	/* HiFi2EP */
+#define XCHAL_HAVE_HIFI_MINI		0	
+
+
+
+#define XCHAL_HAVE_VECTORFPU2005	0	/* vector floating-point pkg */
+#define XCHAL_HAVE_USER_DPFPU		0       /* user DP floating-point pkg */
+#define XCHAL_HAVE_USER_SPFPU		1       /* user SP floating-point pkg */
+#define XCHAL_HAVE_FP			1	/* single prec floating point */
+#define XCHAL_HAVE_FP_DIV		1	/* FP with DIV instructions */
+#define XCHAL_HAVE_FP_RECIP		1	/* FP with RECIP instructions */
+#define XCHAL_HAVE_FP_SQRT		1	/* FP with SQRT instructions */
+#define XCHAL_HAVE_FP_RSQRT		1	/* FP with RSQRT instructions */
+#define XCHAL_HAVE_DFP			0	/* double precision FP pkg */
+#define XCHAL_HAVE_DFP_DIV		0	/* DFP with DIV instructions */
+#define XCHAL_HAVE_DFP_RECIP		0	/* DFP with RECIP instructions*/
+#define XCHAL_HAVE_DFP_SQRT		0	/* DFP with SQRT instructions */
+#define XCHAL_HAVE_DFP_RSQRT		0	/* DFP with RSQRT instructions*/
+#define XCHAL_HAVE_DFP_ACCEL		1	/* double precision FP acceleration pkg */
+#define XCHAL_HAVE_DFP_accel		XCHAL_HAVE_DFP_ACCEL	/* for backward compatibility */
+
+#define XCHAL_HAVE_DFPU_SINGLE_ONLY	0	/* DFPU Coprocessor, single precision only */
+#define XCHAL_HAVE_DFPU_SINGLE_DOUBLE	0	/* DFPU Coprocessor, single and double precision */
+#define XCHAL_HAVE_VECTRA1		0	/* Vectra I  pkg */
+#define XCHAL_HAVE_VECTRALX		0	/* Vectra LX pkg */
+
+#define XCHAL_HAVE_FUSIONG		0    /* FusionG */
+#define XCHAL_HAVE_FUSIONG3		0    /* FusionG3 */
+#define XCHAL_HAVE_FUSIONG6		0    /* FusionG6 */
+#define XCHAL_HAVE_FUSIONG_SP_VFPU	0    /* sp_vfpu option on FusionG */
+#define XCHAL_HAVE_FUSIONG_DP_VFPU	0    /* dp_vfpu option on FusionG */
+#define XCHAL_FUSIONG_SIMD32		0    /* simd32 for FusionG */
+
+#define XCHAL_HAVE_FUSIONJ		0    /* FusionJ */
+#define XCHAL_HAVE_FUSIONJ6		0    /* FusionJ6 */
+#define XCHAL_HAVE_FUSIONJ_SP_VFPU	0    /* sp_vfpu option on FusionJ */
+#define XCHAL_HAVE_FUSIONJ_DP_VFPU	0    /* dp_vfpu option on FusionJ */
+#define XCHAL_FUSIONJ_SIMD32		0    /* simd32 for FusionJ */
+
+#define XCHAL_HAVE_PDX			0    /* PDX-LX */
+#define XCHAL_PDX_SIMD32		0    /* simd32 for PDX */
+#define XCHAL_HAVE_PDX4			0    /* PDX4-LX */
+#define XCHAL_HAVE_PDX8			0    /* PDX8-LX */
+#define XCHAL_HAVE_PDX16		0    /* PDX16-LX */
+#define XCHAL_HAVE_PDXNX 		0    /* PDX-NX */
+
+#define XCHAL_HAVE_CONNXD2		0	/* ConnX D2 pkg */
+#define XCHAL_HAVE_CONNXD2_DUALLSFLIX   0	/* ConnX D2 & Dual LoadStore Flix */
+#define XCHAL_HAVE_BALL			0
+#define XCHAL_HAVE_BALLAP		0
+#define XCHAL_HAVE_BBE16		0	/* ConnX BBE16 pkg */
+#define XCHAL_HAVE_BBE16_RSQRT		0	/* BBE16 & vector recip sqrt */
+#define XCHAL_HAVE_BBE16_VECDIV		0	/* BBE16 & vector divide */
+#define XCHAL_HAVE_BBE16_DESPREAD	0	/* BBE16 & despread */
+#define XCHAL_HAVE_CONNX_B10            0    /* ConnX B10 pkg*/
+#define XCHAL_HAVE_CONNX_B20            0    /* ConnX B20 pkg*/
+#define XCHAL_HAVE_CONNX_B_DP_VFPU      0    /* Double-precision Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_DPX_VFPU     0    /* Double-precision Vector Floating-point option on FP Machine*/
+#define XCHAL_HAVE_CONNX_B_SP_VFPU      0    /* Single-precision Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_SPX_VFPU     0    /* Single-precision Extended Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_HP_VFPU      0    /* Half-precision Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_HPX_VFPU     0    /* Half-precision Extended Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_32B_MAC      0    /* 32-bit vector MAC (real and complex), FIR & FFT option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_VITERBI      0    /* Viterbi option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_TURBO        0    /* Turbo option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_LDPC         0    /* LDPC option on ConnX B10 & B20 */
+#define XCHAL_HAVE_BBENEP		0	/* ConnX BBENEP pkgs */
+#define XCHAL_HAVE_BBENEP_SP_VFPU	0       /* sp_vfpu option on BBE-EP */
+#define XCHAL_HAVE_BSP3			0	/* ConnX BSP3 pkg */
+#define XCHAL_HAVE_BSP3_TRANSPOSE	0	/* BSP3 & transpose32x32 */
+#define XCHAL_HAVE_SSP16		0	/* ConnX SSP16 pkg */
+#define XCHAL_HAVE_SSP16_VITERBI	0	/* SSP16 & viterbi */
+#define XCHAL_HAVE_TURBO16		0	/* ConnX Turbo16 pkg */
+#define XCHAL_HAVE_BBP16		0	/* ConnX BBP16 pkg */
+#define XCHAL_HAVE_FLIX3		0	/* basic 3-way FLIX option */
+#define XCHAL_HAVE_GRIVPEP		0	/* General Release of IVPEP */
+#define XCHAL_HAVE_GRIVPEP_HISTOGRAM	0       /* Histogram option on GRIVPEP */
+
+#define XCHAL_HAVE_VISION	        0     /* Vision P5/P6 */
+#define XCHAL_VISION_SIMD16             0     /* simd16 for Vision P5/P6 */
+#define XCHAL_VISION_TYPE               0     /* Vision P5, P6, Q6, Q7 or Q8 */
+#define XCHAL_VISION_QUAD_MAC_TYPE      0     /* quad_mac option on Vision P6 */
+#define XCHAL_HAVE_VISION_HISTOGRAM     0     /* histogram option on Vision P5/P6 */
+#define XCHAL_HAVE_VISION_DP_VFPU       0     /* dp_vfpu option on Vision Q7/Q8 */
+#define XCHAL_HAVE_VISION_SP_VFPU       0     /* sp_vfpu option on Vision P5/P6/Q6/Q7 */
+#define XCHAL_HAVE_VISION_SP_VFPU_2XFMAC 0     /* sp_vfpu_2xfma option on Vision Q7 */
+#define XCHAL_HAVE_VISION_HP_VFPU       0     /* hp_vfpu option on Vision P6/Q6 */
+#define XCHAL_HAVE_VISION_HP_VFPU_2XFMAC 0     /* hp_vfpu_2xfma option on Vision Q7 */
+
+#define XCHAL_HAVE_VISIONC	        0     /* Vision C */
+
+#define XCHAL_HAVE_XNNE			0		/* XNNE */
+
+
+/*----------------------------------------------------------------------
+				MISC
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_NUM_LOADSTORE_UNITS	2	/* load/store units */
+#define XCHAL_NUM_WRITEBUFFER_ENTRIES	32	/* size of write buffer */
+#define XCHAL_INST_FETCH_WIDTH		16	/* instr-fetch width in bytes */
+#define XCHAL_DATA_WIDTH		16	/* data width in bytes */
+#define XCHAL_DATA_PIPE_DELAY		2	/* d-side pipeline delay
+						   (1 = 5-stage, 2 = 7-stage) */
+#define XCHAL_CLOCK_GATING_GLOBAL	1	/* global clock gating */
+#define XCHAL_CLOCK_GATING_FUNCUNIT	1	/* funct. unit clock gating */
+/*  In T1050, applies to selected core load and store instructions (see ISA): */
+#define XCHAL_UNALIGNED_LOAD_EXCEPTION	1	/* unaligned loads cause exc. */
+#define XCHAL_UNALIGNED_STORE_EXCEPTION	1	/* unaligned stores cause exc.*/
+#define XCHAL_UNALIGNED_LOAD_HW		0	/* unaligned loads work in hw */
+#define XCHAL_UNALIGNED_STORE_HW	0	/* unaligned stores work in hw*/
+
+#define XCHAL_UNIFIED_LOADSTORE         0
+
+#define XCHAL_SW_VERSION		1411000	/* sw version of this header */
+#define XCHAL_SW_VERSION_MAJOR		14000	/* major ver# of sw          */
+#define XCHAL_SW_VERSION_MINOR		11	/* minor ver# of sw          */
+#define XCHAL_SW_VERSION_MICRO		0	/* micro ver# of sw          */
+#define XCHAL_SW_MINOR_VERSION		1411000	/* with zeroed micro */
+#define XCHAL_SW_MICRO_VERSION		1411000
+
+#define XCHAL_CORE_ID			"nxp_rt600_RI23_11_newlib"	/* alphanum core name
+						   (CoreID) set in the Xtensa
+						   Processor Generator */
+
+#define XCHAL_BUILD_UNIQUE_ID		0x000A98E8	/* 22-bit sw build ID */
+
+/*
+ *  These definitions describe the hardware targeted by this software.
+ */
+#define XCHAL_HW_CONFIGID0		0xC2F3FFFE	/* ConfigID hi 32 bits*/
+#define XCHAL_HW_CONFIGID1		0x1D06FB2F	/* ConfigID lo 32 bits*/
+#define XCHAL_HW_VERSION_NAME		"LX6.0.4"	/* full version name */
+#define XCHAL_HW_VERSION_MAJOR		2600	/* major ver# of targeted hw */
+#define XCHAL_HW_VERSION_MINOR		4	/* minor ver# of targeted hw */
+#define XCHAL_HW_VERSION_MICRO		0	/* subdot ver# of targeted hw */
+#define XCHAL_HW_VERSION		260004	/* major*100+(major<2810 ? minor : minor*10+micro) */
+#define XCHAL_HW_REL_LX6		1
+#define XCHAL_HW_REL_LX6_0		1
+#define XCHAL_HW_REL_LX6_0_4		1
+#define XCHAL_HW_CONFIGID_RELIABLE	1
+/*  If software targets a *range* of hardware versions, these are the bounds: */
+#define XCHAL_HW_MIN_VERSION_MAJOR	2600	/* major v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MINOR	4	/* minor v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MICRO	0	/* micro v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION		260004	/* earliest targeted hw */
+#define XCHAL_HW_MAX_VERSION_MAJOR	2600	/* major v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MINOR	4	/* minor v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MICRO	0	/* micro v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION		260004	/* latest targeted hw */
+
+/*  Config is enabled for functional safety: */
+#define XCHAL_HAVE_FUNC_SAFETY		0
+
+/*  Config is enabled for secure operation: */
+#define XCHAL_HAVE_SECURE     		0
+
+#define XCHAL_HAVE_APB			0 
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_ICACHE_LINESIZE		256	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		256	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		8	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		8	/* log2(D line size in bytes) */
+
+#define XCHAL_ICACHE_SIZE		32768	/* I-cache size in bytes or 0 */
+#define XCHAL_ICACHE_SIZE_LOG2		15
+#define XCHAL_DCACHE_SIZE		65536	/* D-cache size in bytes or 0 */
+#define XCHAL_DCACHE_SIZE_LOG2		16
+
+#define XCHAL_DCACHE_IS_WRITEBACK	1	/* writeback feature */
+#define XCHAL_DCACHE_IS_COHERENT	0	/* MP coherence feature */
+
+#define XCHAL_HAVE_PREFETCH		1	/* PREFCTL register */
+#define XCHAL_HAVE_PREFETCH_L1		1	/* prefetch to L1 cache */
+#define XCHAL_PREFETCH_CASTOUT_LINES	1	/* dcache pref. castout bufsz */
+#define XCHAL_PREFETCH_ENTRIES		16	/* cache prefetch entries */
+#define XCHAL_PREFETCH_BLOCK_ENTRIES	8	/* prefetch block streams */
+#define XCHAL_HAVE_CACHE_BLOCKOPS	1	/* block prefetch for caches */
+#define XCHAL_HAVE_CME_DOWNGRADES	0
+#define XCHAL_HAVE_ICACHE_TEST		1	/* Icache test instructions */
+#define XCHAL_HAVE_DCACHE_TEST		1	/* Dcache test instructions */
+#define XCHAL_HAVE_ICACHE_DYN_WAYS	0	/* Icache dynamic way support */
+#define XCHAL_HAVE_DCACHE_DYN_WAYS	0	/* Dcache dynamic way support */
+#define XCHAL_HAVE_ICACHE_DYN_ENABLE	0	/* Icache enabled via MEMCTL */
+#define XCHAL_HAVE_DCACHE_DYN_ENABLE	0	/* Dcache enabled via MEMCTL */
+
+#define XCHAL_L1SCACHE_SIZE		0
+#define XCHAL_L1SCACHE_SIZE_LOG2	0
+#define XCHAL_L1SCACHE_WAYS		1
+#define XCHAL_L1SCACHE_WAYS_LOG2	0
+#define XCHAL_L1SCACHE_ACCESS_SIZE	0
+#define XCHAL_L1SCACHE_BANKS		1
+
+#define XCHAL_L1VCACHE_SIZE		0
+
+#define XCHAL_HAVE_L2			0	/* NX L2 cache controller */
+#define XCHAL_HAVE_L2_CACHE		0
+#define XCHAL_NUM_CORES_IN_CLUSTER	0
+
+/* PRID_ID macros are for internal use only ... subject to removal */
+#define PRID_ID_SHIFT           0
+#define PRID_ID_BITS            4
+#define PRID_ID_MASK            0x0000000F
+
+/*  This one is a form of caching, though not architecturally visible:  */
+#define XCHAL_HAVE_BRANCH_PREDICTION	0	/* branch [target] prediction */
+
+
+
+
+/****************************************************************************
+    Parameters Useful for PRIVILEGED (Supervisory or Non-Virtualized) Code
+ ****************************************************************************/
+
+
+#ifndef XTENSA_HAL_NON_PRIVILEGED_ONLY
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_PIF			1	/* any outbound bus present */
+
+#define XCHAL_HAVE_AXI			0	/* AXI bus */
+#define XCHAL_HAVE_AXI_ECC		0	/* ECC on AXI bus */
+#define XCHAL_HAVE_ACELITE		0	/* ACELite bus */
+
+#define XCHAL_HAVE_PIF_WR_RESP			0	/* pif write response */
+#define XCHAL_HAVE_PIF_REQ_ATTR			0	/* pif attribute */
+
+/*  If present, cache size in bytes == (ways * 2^(linewidth + setwidth)).  */
+
+/*  Number of cache sets in log2(lines per way):  */
+#define XCHAL_ICACHE_SETWIDTH		5
+#define XCHAL_DCACHE_SETWIDTH		6
+
+/*  Cache set associativity (number of ways):  */
+#define XCHAL_ICACHE_WAYS		4
+#define XCHAL_ICACHE_WAYS_LOG2		2
+#define XCHAL_DCACHE_WAYS		4
+#define XCHAL_DCACHE_WAYS_LOG2		2
+
+/*  Cache features:  */
+#define XCHAL_ICACHE_LINE_LOCKABLE	1
+#define XCHAL_DCACHE_LINE_LOCKABLE	1
+#define XCHAL_ICACHE_ECC_PARITY		0
+#define XCHAL_DCACHE_ECC_PARITY		0
+#define XCHAL_ICACHE_ECC_WIDTH		4
+#define XCHAL_DCACHE_ECC_WIDTH		1
+
+/*  Cache access size in bytes (affects operation of SICW instruction):  */
+#define XCHAL_ICACHE_ACCESS_SIZE	16
+#define XCHAL_DCACHE_ACCESS_SIZE	16
+
+#define XCHAL_DCACHE_BANKS		4	/* number of banks */
+
+/* The number of Cache lines associated with a single cache tag */
+#define XCHAL_DCACHE_LINES_PER_TAG_LOG2	0
+
+/*  Number of encoded cache attr bits (see <xtensa/hal.h> for decoded bits):  */
+#define XCHAL_CA_BITS			4
+
+/*  Extended memory attributes supported.  */
+#define XCHAL_HAVE_EXT_CA		0
+
+
+/*----------------------------------------------------------------------
+			INTERNAL I/D RAM/ROMs and XLMI
+  ----------------------------------------------------------------------*/
+#define XCHAL_NUM_INSTROM		0	/* number of core instr. ROMs */
+#define XCHAL_NUM_INSTRAM		1	/* number of core instr. RAMs */
+#define XCHAL_NUM_DATAROM		0	/* number of core data ROMs */
+#define XCHAL_NUM_DATARAM		1	/* number of core data RAMs */
+#define XCHAL_NUM_URAM			0	/* number of core unified RAMs*/
+#define XCHAL_NUM_XLMI			0	/* number of core XLMI ports */
+#define	XCHAL_HAVE_IRAMCFG		0	/* IRAMxCFG register present */
+#define	XCHAL_HAVE_DRAMCFG		0	/* DRAMxCFG register present */
+
+/*  Instruction RAM 0:  */
+#define XCHAL_INSTRAM0_VADDR		0x24020000	/* virtual address */
+#define XCHAL_INSTRAM0_PADDR		0x24020000	/* physical address */
+#define XCHAL_INSTRAM0_SIZE		65536	/* size in bytes */
+#define XCHAL_INSTRAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_HAVE_INSTRAM0		1
+#define XCHAL_INSTRAM0_HAVE_IDMA	0	/* idma supported by this local memory */
+
+/*  Data RAM 0:  */
+#define XCHAL_DATARAM0_VADDR		0x24000000	/* virtual address */
+#define XCHAL_DATARAM0_PADDR		0x24000000	/* physical address */
+#define XCHAL_DATARAM0_SIZE		65536	/* size in bytes */
+#define XCHAL_DATARAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_DATARAM0_BANKS		4	/* number of banks */
+#define XCHAL_HAVE_DATARAM0		1
+#define XCHAL_DATARAM0_HAVE_IDMA	0	/* idma supported by this local memory */
+
+#define XCHAL_HAVE_IMEM_LOADSTORE	1	/* can load/store to IROM/IRAM*/
+
+
+/*----------------------------------------------------------------------
+			IDMA
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_IDMA			0
+
+
+
+/*----------------------------------------------------------------------
+			INTERRUPTS and TIMERS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_INTERRUPTS		1	/* interrupt option */
+#define XCHAL_HAVE_NMI			1	/* non-maskable interrupt */
+#define XCHAL_HAVE_CCOUNT		1	/* CCOUNT reg. (timer option) */
+#define XCHAL_NUM_TIMERS		2	/* number of CCOMPAREn regs */
+#define XCHAL_NUM_INTERRUPTS		32	/* number of interrupts */
+#define XCHAL_NUM_INTERRUPTS_LOG2	5	/* ceil(log2(NUM_INTERRUPTS)) */
+#define XCHAL_NUM_EXTINTERRUPTS		28	/* num of external interrupts */
+#define XCHAL_NUM_INTLEVELS		4	/* number of interrupt levels
+						   (not including level zero) */
+#define XCHAL_INTERRUPT_RANGE		32	/* range of interrupt numbers */
+
+
+#define XCHAL_HAVE_HIGHPRI_INTERRUPTS	1   /* med/high-pri. interrupts */
+#define XCHAL_EXCM_LEVEL		2	/* level masked by PS.EXCM */
+	/* (always 1 in XEA1; levels 2 .. EXCM_LEVEL are "medium priority") */
+
+/*  Masks of interrupts at each interrupt level:  */
+#define XCHAL_INTLEVEL1_MASK		0x0000FFE0
+#define XCHAL_INTLEVEL2_MASK		0x00FF0006
+#define XCHAL_INTLEVEL3_MASK		0xFF000018
+#define XCHAL_INTLEVEL4_MASK		0x00000000
+#define XCHAL_INTLEVEL5_MASK		0x00000001
+#define XCHAL_INTLEVEL6_MASK		0x00000000
+#define XCHAL_INTLEVEL7_MASK		0x00000000
+
+/*  Masks of interrupts at each range 1..n of interrupt levels:  */
+#define XCHAL_INTLEVEL1_ANDBELOW_MASK	0x0000FFE0
+#define XCHAL_INTLEVEL2_ANDBELOW_MASK	0x00FFFFE6
+#define XCHAL_INTLEVEL3_ANDBELOW_MASK	0xFFFFFFFE
+#define XCHAL_INTLEVEL4_ANDBELOW_MASK	0xFFFFFFFE
+#define XCHAL_INTLEVEL5_ANDBELOW_MASK	0xFFFFFFFF
+#define XCHAL_INTLEVEL6_ANDBELOW_MASK	0xFFFFFFFF
+#define XCHAL_INTLEVEL7_ANDBELOW_MASK	0xFFFFFFFF
+
+/*  Level of each interrupt:  */
+#define XCHAL_INT0_LEVEL		5
+#define XCHAL_INT1_LEVEL		2
+#define XCHAL_INT2_LEVEL		2
+#define XCHAL_INT3_LEVEL		3
+#define XCHAL_INT4_LEVEL		3
+#define XCHAL_INT5_LEVEL		1
+#define XCHAL_INT6_LEVEL		1
+#define XCHAL_INT7_LEVEL		1
+#define XCHAL_INT8_LEVEL		1
+#define XCHAL_INT9_LEVEL		1
+#define XCHAL_INT10_LEVEL		1
+#define XCHAL_INT11_LEVEL		1
+#define XCHAL_INT12_LEVEL		1
+#define XCHAL_INT13_LEVEL		1
+#define XCHAL_INT14_LEVEL		1
+#define XCHAL_INT15_LEVEL		1
+#define XCHAL_INT16_LEVEL		2
+#define XCHAL_INT17_LEVEL		2
+#define XCHAL_INT18_LEVEL		2
+#define XCHAL_INT19_LEVEL		2
+#define XCHAL_INT20_LEVEL		2
+#define XCHAL_INT21_LEVEL		2
+#define XCHAL_INT22_LEVEL		2
+#define XCHAL_INT23_LEVEL		2
+#define XCHAL_INT24_LEVEL		3
+#define XCHAL_INT25_LEVEL		3
+#define XCHAL_INT26_LEVEL		3
+#define XCHAL_INT27_LEVEL		3
+#define XCHAL_INT28_LEVEL		3
+#define XCHAL_INT29_LEVEL		3
+#define XCHAL_INT30_LEVEL		3
+#define XCHAL_INT31_LEVEL		3
+#define XCHAL_DEBUGLEVEL		4	/* debug interrupt level */
+#define XCHAL_HAVE_DEBUG_EXTERN_INT	1	/* OCD external db interrupt */
+#define XCHAL_NMILEVEL			5	/* NMI "level" (for use with
+						   EXCSAVE/EPS/EPC_n, RFI n) */
+
+/*  Type of each interrupt:  */
+#define XCHAL_INT0_TYPE 	XTHAL_INTTYPE_NMI
+#define XCHAL_INT1_TYPE 	XTHAL_INTTYPE_SOFTWARE
+#define XCHAL_INT2_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT3_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT4_TYPE 	XTHAL_INTTYPE_PROFILING
+#define XCHAL_INT5_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT6_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT7_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT8_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT9_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT10_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT11_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT12_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT13_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT14_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT15_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT16_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT17_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT18_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT19_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT20_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT21_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT22_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT23_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT24_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT25_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT26_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT27_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT28_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT29_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT30_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT31_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+
+/*  Masks of interrupts for each type of interrupt:  */
+#define XCHAL_INTTYPE_MASK_UNCONFIGURED	0x00000000
+#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0xFFFFFFE0
+#define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x00000000
+#define XCHAL_INTTYPE_MASK_NMI		0x00000001
+#define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000002
+#define XCHAL_INTTYPE_MASK_TIMER	0x0000000C
+#define XCHAL_INTTYPE_MASK_ETIE		0x00000000
+#define XCHAL_INTTYPE_MASK_WRITE_ERROR	0x00000000
+#define XCHAL_INTTYPE_MASK_DBG_REQUEST	0x00000000
+#define XCHAL_INTTYPE_MASK_BREAKIN	0x00000000
+#define XCHAL_INTTYPE_MASK_TRAX		0x00000000
+#define XCHAL_INTTYPE_MASK_PROFILING	0x00000010
+#define XCHAL_INTTYPE_MASK_IDMA_DONE	0x00000000
+#define XCHAL_INTTYPE_MASK_IDMA_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_GS_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_L2_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_L2_STATUS	0x00000000
+#define XCHAL_INTTYPE_MASK_COR_ECC_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_WWDT		0x00000000
+#define XCHAL_INTTYPE_MASK_FXLK		0x00000000
+
+/*  Interrupt numbers assigned to specific interrupt sources:  */
+#define XCHAL_TIMER0_INTERRUPT		2	/* CCOMPARE0 */
+#define XCHAL_TIMER1_INTERRUPT		3	/* CCOMPARE1 */
+#define XCHAL_TIMER2_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_TIMER3_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_NMI_INTERRUPT		0	/* non-maskable interrupt */
+#define XCHAL_PROFILING_INTERRUPT	4
+
+/*  Interrupt numbers for levels at which only one interrupt is configured:  */
+#define XCHAL_INTLEVEL5_NUM		0
+/*  (There are many interrupts each at level(s) 1, 2, 3.)  */
+
+
+/*
+ *  External interrupt mapping.
+ *  These macros describe how Xtensa processor interrupt numbers
+ *  (as numbered internally, eg. in INTERRUPT and INTENABLE registers)
+ *  map to external BInterrupt<n> pins, for those interrupts
+ *  configured as external (level-triggered, edge-triggered, or NMI).
+ *  See the Xtensa processor databook for more details.
+ */
+
+/*  Core interrupt numbers mapped to each EXTERNAL BInterrupt pin number:  */
+#define XCHAL_EXTINT0_NUM		0	/* (intlevel 5) */
+#define XCHAL_EXTINT1_NUM		5	/* (intlevel 1) */
+#define XCHAL_EXTINT2_NUM		6	/* (intlevel 1) */
+#define XCHAL_EXTINT3_NUM		7	/* (intlevel 1) */
+#define XCHAL_EXTINT4_NUM		8	/* (intlevel 1) */
+#define XCHAL_EXTINT5_NUM		9	/* (intlevel 1) */
+#define XCHAL_EXTINT6_NUM		10	/* (intlevel 1) */
+#define XCHAL_EXTINT7_NUM		11	/* (intlevel 1) */
+#define XCHAL_EXTINT8_NUM		12	/* (intlevel 1) */
+#define XCHAL_EXTINT9_NUM		13	/* (intlevel 1) */
+#define XCHAL_EXTINT10_NUM		14	/* (intlevel 1) */
+#define XCHAL_EXTINT11_NUM		15	/* (intlevel 1) */
+#define XCHAL_EXTINT12_NUM		16	/* (intlevel 2) */
+#define XCHAL_EXTINT13_NUM		17	/* (intlevel 2) */
+#define XCHAL_EXTINT14_NUM		18	/* (intlevel 2) */
+#define XCHAL_EXTINT15_NUM		19	/* (intlevel 2) */
+#define XCHAL_EXTINT16_NUM		20	/* (intlevel 2) */
+#define XCHAL_EXTINT17_NUM		21	/* (intlevel 2) */
+#define XCHAL_EXTINT18_NUM		22	/* (intlevel 2) */
+#define XCHAL_EXTINT19_NUM		23	/* (intlevel 2) */
+#define XCHAL_EXTINT20_NUM		24	/* (intlevel 3) */
+#define XCHAL_EXTINT21_NUM		25	/* (intlevel 3) */
+#define XCHAL_EXTINT22_NUM		26	/* (intlevel 3) */
+#define XCHAL_EXTINT23_NUM		27	/* (intlevel 3) */
+#define XCHAL_EXTINT24_NUM		28	/* (intlevel 3) */
+#define XCHAL_EXTINT25_NUM		29	/* (intlevel 3) */
+#define XCHAL_EXTINT26_NUM		30	/* (intlevel 3) */
+#define XCHAL_EXTINT27_NUM		31	/* (intlevel 3) */
+/*  EXTERNAL BInterrupt pin numbers mapped to each core interrupt number:  */
+#define XCHAL_INT0_EXTNUM		0	/* (intlevel 5) */
+#define XCHAL_INT5_EXTNUM		1	/* (intlevel 1) */
+#define XCHAL_INT6_EXTNUM		2	/* (intlevel 1) */
+#define XCHAL_INT7_EXTNUM		3	/* (intlevel 1) */
+#define XCHAL_INT8_EXTNUM		4	/* (intlevel 1) */
+#define XCHAL_INT9_EXTNUM		5	/* (intlevel 1) */
+#define XCHAL_INT10_EXTNUM		6	/* (intlevel 1) */
+#define XCHAL_INT11_EXTNUM		7	/* (intlevel 1) */
+#define XCHAL_INT12_EXTNUM		8	/* (intlevel 1) */
+#define XCHAL_INT13_EXTNUM		9	/* (intlevel 1) */
+#define XCHAL_INT14_EXTNUM		10	/* (intlevel 1) */
+#define XCHAL_INT15_EXTNUM		11	/* (intlevel 1) */
+#define XCHAL_INT16_EXTNUM		12	/* (intlevel 2) */
+#define XCHAL_INT17_EXTNUM		13	/* (intlevel 2) */
+#define XCHAL_INT18_EXTNUM		14	/* (intlevel 2) */
+#define XCHAL_INT19_EXTNUM		15	/* (intlevel 2) */
+#define XCHAL_INT20_EXTNUM		16	/* (intlevel 2) */
+#define XCHAL_INT21_EXTNUM		17	/* (intlevel 2) */
+#define XCHAL_INT22_EXTNUM		18	/* (intlevel 2) */
+#define XCHAL_INT23_EXTNUM		19	/* (intlevel 2) */
+#define XCHAL_INT24_EXTNUM		20	/* (intlevel 3) */
+#define XCHAL_INT25_EXTNUM		21	/* (intlevel 3) */
+#define XCHAL_INT26_EXTNUM		22	/* (intlevel 3) */
+#define XCHAL_INT27_EXTNUM		23	/* (intlevel 3) */
+#define XCHAL_INT28_EXTNUM		24	/* (intlevel 3) */
+#define XCHAL_INT29_EXTNUM		25	/* (intlevel 3) */
+#define XCHAL_INT30_EXTNUM		26	/* (intlevel 3) */
+#define XCHAL_INT31_EXTNUM		27	/* (intlevel 3) */
+
+#define	XCHAL_HAVE_ISB			0	/* No ISB */
+#define	XCHAL_ISB_VADDR			0	/* N/A    */
+#define	XCHAL_HAVE_ITB			0	/* No ITB */
+#define	XCHAL_ITB_VADDR			0	/* N/A    */
+
+#define	XCHAL_HAVE_KSL			0	/* Kernel Stack Limit */
+#define	XCHAL_HAVE_ISL			0	/* Interrupt Stack Limit */
+#define	XCHAL_HAVE_PSL			0	/* Pageable Stack Limit */
+
+
+/*----------------------------------------------------------------------
+			EXCEPTIONS and VECTORS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_XEA_VERSION		2	/* Xtensa Exception Architecture
+						   number: 1 == XEA1 (until T1050)
+							   2 == XEA2 (LX)
+							   3 == XEA3 (NX)
+							   0 == XEA5 (RNX) */
+#define XCHAL_HAVE_XEA1			0	/* Exception Architecture 1 */
+#define XCHAL_HAVE_XEA2			1	/* Exception Architecture 2 */
+#define XCHAL_HAVE_XEA3			0	/* Exception Architecture 3 */
+#define XCHAL_HAVE_XEA5			0	/* Exception Architecture 5 */
+#define XCHAL_HAVE_EXCEPTIONS		1	/* exception option */
+#define XCHAL_HAVE_IMPRECISE_EXCEPTIONS	0	/* imprecise exception option */
+#define	XCHAL_EXCCAUSE_NUM		64	/* Number of exceptions */
+#define XCHAL_HAVE_HALT			0	/* halt architecture option */
+#define XCHAL_HAVE_BOOTLOADER		0	/* boot loader (for TX) */
+#define XCHAL_HAVE_MEM_ECC_PARITY	0	/* local memory ECC/parity */
+#define XCHAL_HAVE_VECTOR_SELECT	1	/* relocatable vectors */
+#define XCHAL_HAVE_VECBASE		1	/* relocatable vectors */
+#define XCHAL_VECBASE_RESET_VADDR	0x24020400  /* VECBASE reset value */
+#define XCHAL_VECBASE_RESET_PADDR	0x24020400
+#define XCHAL_RESET_VECBASE_OVERLAP	0	/* UNUSED */
+
+#define XCHAL_RESET_VECTOR0_VADDR	0x24020000
+#define XCHAL_RESET_VECTOR0_PADDR	0x24020000
+#define XCHAL_RESET_VECTOR1_VADDR	0x20100000
+#define XCHAL_RESET_VECTOR1_PADDR	0x20100000
+#define XCHAL_RESET_VECTOR_VADDR	XCHAL_RESET_VECTOR0_VADDR
+#define XCHAL_RESET_VECTOR_PADDR	XCHAL_RESET_VECTOR0_PADDR
+#define XCHAL_USER_VECOFS		0x0000021C
+#define XCHAL_USER_VECTOR_VADDR		0x2402061C
+#define XCHAL_USER_VECTOR_PADDR		0x2402061C
+#define XCHAL_KERNEL_VECOFS		0x000001FC
+#define XCHAL_KERNEL_VECTOR_VADDR	0x240205FC
+#define XCHAL_KERNEL_VECTOR_PADDR	0x240205FC
+#define XCHAL_DOUBLEEXC_VECOFS		0x0000023C
+#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x2402063C
+#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x2402063C
+#define XCHAL_WINDOW_OF4_VECOFS		0x00000000
+#define XCHAL_WINDOW_UF4_VECOFS		0x00000040
+#define XCHAL_WINDOW_OF8_VECOFS		0x00000080
+#define XCHAL_WINDOW_UF8_VECOFS		0x000000C0
+#define XCHAL_WINDOW_OF12_VECOFS	0x00000100
+#define XCHAL_WINDOW_UF12_VECOFS	0x00000140
+#define XCHAL_WINDOW_VECTORS_VADDR	0x24020400
+#define XCHAL_WINDOW_VECTORS_PADDR	0x24020400
+#define XCHAL_INTLEVEL2_VECOFS		0x0000017C
+#define XCHAL_INTLEVEL2_VECTOR_VADDR	0x2402057C
+#define XCHAL_INTLEVEL2_VECTOR_PADDR	0x2402057C
+#define XCHAL_INTLEVEL3_VECOFS		0x0000019C
+#define XCHAL_INTLEVEL3_VECTOR_VADDR	0x2402059C
+#define XCHAL_INTLEVEL3_VECTOR_PADDR	0x2402059C
+#define XCHAL_INTLEVEL4_VECOFS		0x000001BC
+#define XCHAL_INTLEVEL4_VECTOR_VADDR	0x240205BC
+#define XCHAL_INTLEVEL4_VECTOR_PADDR	0x240205BC
+#define XCHAL_DEBUG_VECOFS		XCHAL_INTLEVEL4_VECOFS
+#define XCHAL_DEBUG_VECTOR_VADDR	XCHAL_INTLEVEL4_VECTOR_VADDR
+#define XCHAL_DEBUG_VECTOR_PADDR	XCHAL_INTLEVEL4_VECTOR_PADDR
+#define XCHAL_NMI_VECOFS		0x000001DC
+#define XCHAL_NMI_VECTOR_VADDR		0x240205DC
+#define XCHAL_NMI_VECTOR_PADDR		0x240205DC
+#define XCHAL_INTLEVEL5_VECOFS		XCHAL_NMI_VECOFS
+#define XCHAL_INTLEVEL5_VECTOR_VADDR	XCHAL_NMI_VECTOR_VADDR
+#define XCHAL_INTLEVEL5_VECTOR_PADDR	XCHAL_NMI_VECTOR_PADDR
+
+
+/*----------------------------------------------------------------------
+				DEBUG MODULE
+  ----------------------------------------------------------------------*/
+
+/*  Misc  */
+#define XCHAL_HAVE_DEBUG_ERI		1	/* ERI to debug module */
+#define XCHAL_HAVE_DEBUG_APB		1	/* APB to debug module */
+#define XCHAL_HAVE_DEBUG_JTAG		1	/* JTAG to debug module */
+
+/*  On-Chip Debug (OCD)  */
+#define XCHAL_HAVE_OCD			1	/* OnChipDebug option */
+#define XCHAL_NUM_IBREAK		2	/* number of IBREAKn regs */
+#define XCHAL_NUM_DBREAK		2	/* number of DBREAKn regs */
+#define XCHAL_HAVE_OCD_DIR_ARRAY	0	/* faster OCD option (to LX4) */
+#define XCHAL_HAVE_OCD_LS32DDR		1	/* L32DDR/S32DDR (faster OCD) */
+
+/*  TRAX (in core)  */
+#define XCHAL_HAVE_TRAX			0	/* TRAX in debug module */
+#define XCHAL_TRAX_MEM_SIZE		0	/* TRAX memory size in bytes */
+#define XCHAL_TRAX_MEM_SHAREABLE	0	/* start/end regs; ready sig. */
+#define XCHAL_TRAX_ATB_WIDTH		0	/* ATB width (bits), 0=no ATB */
+#define XCHAL_TRAX_TIME_WIDTH		0	/* timestamp bitwidth, 0=none */
+
+/*  Perf counters  */
+#define XCHAL_NUM_PERF_COUNTERS		2	/* performance counters */
+
+
+/*----------------------------------------------------------------------
+				MMU
+  ----------------------------------------------------------------------*/
+
+/*  See core-matmap.h header file for more details.  */
+
+#define XCHAL_HAVE_TLBS			1	/* inverse of HAVE_CACHEATTR */
+#define XCHAL_HAVE_SPANNING_WAY		1	/* one way maps I+D 4GB vaddr */
+#define XCHAL_SPANNING_WAY		0	/* TLB spanning way number */
+#define XCHAL_HAVE_IDENTITY_MAP		1	/* vaddr == paddr always */
+#define XCHAL_HAVE_CACHEATTR		0	/* CACHEATTR register present */
+#define XCHAL_HAVE_MIMIC_CACHEATTR	1	/* region protection */
+#define XCHAL_HAVE_XLT_CACHEATTR	0	/* region prot. w/translation */
+#define XCHAL_HAVE_PTP_MMU		0	/* full MMU (with page table
+						   [autorefill] and protection)
+						   usable for an MMU-based OS */
+
+/*  If none of the above last 5 are set, it's a custom TLB configuration.  */
+
+#define XCHAL_MMU_ASID_BITS		0	/* number of bits in ASIDs */
+#define XCHAL_MMU_RINGS			1	/* number of rings (1..4) */
+#define XCHAL_MMU_RING_BITS		0	/* num of bits in RING field */
+
+/*----------------------------------------------------------------------
+				MPU
+  ----------------------------------------------------------------------*/
+#define XCHAL_HAVE_MPU			0 
+#define XCHAL_MPU_ENTRIES		0
+#define XCHAL_MPU_LOCK			0
+
+#define XCHAL_MPU_ALIGN_REQ		1	/* MPU requires alignment of entries to background map */
+#define XCHAL_MPU_BACKGROUND_ENTRIES	0	/* number of entries in bg map*/
+#define XCHAL_MPU_BG_CACHEADRDIS	0	/* default CACHEADRDIS for bg */
+ 
+#define XCHAL_MPU_ALIGN_BITS		0
+#define XCHAL_MPU_ALIGN			0
+
+/*-----------------------------------------------------------------------
+				CSR Parity
+------------------------------------------------------------------------*/
+#define XCHAL_HAVE_CSR_PARITY		0
+
+
+/*----------------------------------------------------------------------
+				FLEX-LOCK
+------------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_FXLK			0
+
+/*----------------------------------------------------------------------
+				WWDT (Windowed Watchdog Timer)
+------------------------------------------------------------------------*/
+#define XCHAL_HAVE_WWDT			0
+#endif /* !XTENSA_HAL_NON_PRIVILEGED_ONLY */
+
+
+#endif /* XTENSA_CORE_CONFIGURATION_H_ */
+

--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/core-matmap.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/core-matmap.h
@@ -1,0 +1,319 @@
+/* 
+ * xtensa/config/core-matmap.h -- Memory access and translation mapping
+ *	parameters (CHAL) of the Xtensa processor core configuration.
+ *
+ *  If you are using Xtensa Tools, see <xtensa/config/core.h> (which includes
+ *  this file) for more details.
+ *
+ *  In the Xtensa processor products released to date, all parameters
+ *  defined in this file are derivable (at least in theory) from
+ *  information contained in the core-isa.h header file.
+ *  In particular, the following core configuration parameters are relevant:
+ *	XCHAL_HAVE_CACHEATTR
+ *	XCHAL_HAVE_MIMIC_CACHEATTR
+ *	XCHAL_HAVE_XLT_CACHEATTR
+ *	XCHAL_HAVE_PTP_MMU
+ *	XCHAL_ITLB_ARF_ENTRIES_LOG2
+ *	XCHAL_DTLB_ARF_ENTRIES_LOG2
+ *	XCHAL_DCACHE_IS_WRITEBACK
+ *	XCHAL_ICACHE_SIZE		(presence of I-cache)
+ *	XCHAL_DCACHE_SIZE		(presence of D-cache)
+ *	XCHAL_HW_VERSION_MAJOR
+ *	XCHAL_HW_VERSION_MINOR
+ */
+
+/* Copyright (c) 1999-2022 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+
+#ifndef XTENSA_CONFIG_CORE_MATMAP_H
+#define XTENSA_CONFIG_CORE_MATMAP_H
+
+
+/*----------------------------------------------------------------------
+			CACHE (MEMORY ACCESS) ATTRIBUTES
+  ----------------------------------------------------------------------*/
+
+
+
+/*  Cache Attribute encodings -- lists of access modes for each cache attribute:  */
+#define XCHAL_FCA_LIST		XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_BYPASS	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_BYPASS	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION
+#define XCHAL_LCA_LIST		XTHAL_LAM_CACHED_NOALLOC	XCHAL_SEP \
+				XTHAL_LAM_CACHED	XCHAL_SEP \
+				XTHAL_LAM_BYPASSG	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_CACHED	XCHAL_SEP \
+				XTHAL_LAM_CACHED	XCHAL_SEP \
+				XTHAL_LAM_BYPASSG	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_ISOLATE	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION
+#define XCHAL_SCA_LIST		XTHAL_SAM_WRITETHRU	XCHAL_SEP \
+				XTHAL_SAM_WRITETHRU	XCHAL_SEP \
+				XTHAL_SAM_BYPASS	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_WRITEBACK	XCHAL_SEP \
+				XTHAL_SAM_WRITEBACK_NOALLOC	XCHAL_SEP \
+				XTHAL_SAM_BYPASS	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_ISOLATE	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION
+
+/*  The following defines are deprecated. DO NOT USE.  */
+#define XCHAL_CA_R   (0xC0 | 0x40000000)
+#define XCHAL_CA_RX  (0xD0 | 0x40000000)
+#define XCHAL_CA_RW  (0xE0 | 0x40000000)
+#define XCHAL_CA_RWX (0xF0 | 0x40000000)
+
+/*
+ *  Specific encoded cache attribute values of general interest.
+ *  If a specific cache mode is not available, the closest available
+ *  one is returned instead (eg. writethru instead of writeback,
+ *  bypass instead of writethru).
+ */
+#define XCHAL_CA_BYPASS  		2	/* cache disabled (bypassed) mode */
+#define XCHAL_CA_BYPASSBUF  		6	/* cache disabled (bypassed) bufferable mode */
+#define XCHAL_CA_WRITETHRU		1	/* cache enabled (write-through) mode */
+#define XCHAL_CA_WRITEBACK		4	/* cache enabled (write-back) mode */
+#define XCHAL_HAVE_CA_WRITEBACK_NOALLOC	1	/* write-back no-allocate availability */
+#define XCHAL_CA_WRITEBACK_NOALLOC	5	/* cache enabled (write-back no-allocate) mode */
+#define XCHAL_CA_ILLEGAL		15	/* no access allowed (all cause exceptions) mode */
+#define XCHAL_CA_ISOLATE		14	/* cache isolate (accesses go to cache not memory) mode */
+
+/*----------------------------------------------------------------------
+				MMU
+  ----------------------------------------------------------------------*/
+
+/*
+ *  General notes on MMU parameters.
+ *
+ *  Terminology:
+ *	ASID = address-space ID (acts as an "extension" of virtual addresses)
+ *	VPN  = virtual page number
+ *	PPN  = physical page number
+ *	CA   = encoded cache attribute (access modes)
+ *	TLB  = translation look-aside buffer (term is stretched somewhat here)
+ *	I    = instruction (fetch accesses)
+ *	D    = data (load and store accesses)
+ *	way  = each TLB (ITLB and DTLB) consists of a number of "ways"
+ *		that simultaneously match the virtual address of an access;
+ *		a TLB successfully translates a virtual address if exactly
+ *		one way matches the vaddr; if none match, it is a miss;
+ *		if multiple match, one gets a "multihit" exception;
+ *		each way can be independently configured in terms of number of
+ *		entries, page sizes, which fields are writable or constant, etc.
+ *	set  = group of contiguous ways with exactly identical parameters
+ *	ARF  = auto-refill; hardware services a 1st-level miss by loading a PTE
+ *		from the page table and storing it in one of the auto-refill ways;
+ *		if this PTE load also misses, a miss exception is posted for s/w.
+ *	min-wired = a "min-wired" way can be used to map a single (minimum-sized)
+ * 		page arbitrarily under program control; it has a single entry,
+ *		is non-auto-refill (some other way(s) must be auto-refill),
+ *		all its fields (VPN, PPN, ASID, CA) are all writable, and it
+ *		supports the XCHAL_MMU_MIN_PTE_PAGE_SIZE page size (a current
+ *		restriction is that this be the only page size it supports).
+ *
+ *  TLB way entries are virtually indexed.
+ *  TLB ways that support multiple page sizes:
+ *	- must have all writable VPN and PPN fields;
+ *	- can only use one page size at any given time (eg. setup at startup),
+ *	  selected by the respective ITLBCFG or DTLBCFG special register,
+ *	  whose bits n*4+3 .. n*4 index the list of page sizes for way n
+ *	  (XCHAL_xTLB_SETm_PAGESZ_LOG2_LIST for set m corresponding to way n);
+ *	  this list may be sparse for auto-refill ways because auto-refill
+ *	  ways have independent lists of supported page sizes sharing a
+ *	  common encoding with PTE entries; the encoding is the index into
+ *	  this list; unsupported sizes for a given way are zero in the list;
+ *	  selecting unsupported sizes results in undefine hardware behaviour;
+ *	- is only possible for ways 0 thru 7 (due to ITLBCFG/DTLBCFG definition).
+ */
+
+#define XCHAL_MMU_ASID_INVALID		0	/* ASID value indicating invalid address space */
+#define XCHAL_MMU_ASID_KERNEL		0	/* ASID value indicating kernel (ring 0) address space */
+#define XCHAL_MMU_SR_BITS		0	/* number of size-restriction bits supported */
+#define XCHAL_MMU_CA_BITS		4	 /* number of bits needed to hold cache attribute encoding */
+#define XCHAL_MMU_MAX_PTE_PAGE_SIZE	29	/* max page size in a PTE structure (log2) */
+#define XCHAL_MMU_MIN_PTE_PAGE_SIZE	29	/* min page size in a PTE structure (log2) */
+
+
+/***  Instruction TLB:  ***/
+
+#define XCHAL_ITLB_WAY_BITS		0	/* number of bits holding the ways */
+#define XCHAL_ITLB_WAYS			1	/* number of ways (n-way set-associative TLB) */
+#define XCHAL_ITLB_ARF_WAYS		0	/* number of auto-refill ways */
+#define XCHAL_ITLB_SETS			1	/* number of sets (groups of ways with identical settings) */
+
+/*  Way set to which each way belongs:  */
+#define XCHAL_ITLB_WAY0_SET		0
+
+/*  Ways sets that are used by hardware auto-refill (ARF):  */
+#define XCHAL_ITLB_ARF_SETS		0	/* number of auto-refill sets */
+
+/*  Way sets that are "min-wired" (see terminology comment above):  */
+#define XCHAL_ITLB_MINWIRED_SETS	0	/* number of "min-wired" sets */
+
+
+/*  ITLB way set 0 (group of ways 0 thru 0):  */
+#define XCHAL_ITLB_SET0_WAY			0	/* index of first way in this way set */
+#define XCHAL_ITLB_SET0_WAYS			1	/* number of (contiguous) ways in this way set */
+#define XCHAL_ITLB_SET0_ENTRIES_LOG2		3	/* log2(number of entries in this way) */
+#define XCHAL_ITLB_SET0_ENTRIES			8	/* number of entries in this way (always a power of 2) */
+#define XCHAL_ITLB_SET0_ARF			0	/* 1=autorefill by h/w, 0=non-autorefill (wired/constant/static) */
+#define XCHAL_ITLB_SET0_PAGESIZES		1	/* number of supported page sizes in this way */
+#define XCHAL_ITLB_SET0_PAGESZ_BITS		0	/* number of bits to encode the page size */
+#define XCHAL_ITLB_SET0_PAGESZ_LOG2_MIN		29	/* log2(minimum supported page size) */
+#define XCHAL_ITLB_SET0_PAGESZ_LOG2_MAX		29	/* log2(maximum supported page size) */
+#define XCHAL_ITLB_SET0_PAGESZ_LOG2_LIST	29	/* list of log2(page size)s, separated by XCHAL_SEP;
+							   2^PAGESZ_BITS entries in list, unsupported entries are zero */
+#define XCHAL_ITLB_SET0_ASID_CONSTMASK		0	/* constant ASID bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_VPN_CONSTMASK		0x00000000	/* constant VPN bits, not including entry index bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_PPN_CONSTMASK		0xE0000000	/* constant PPN bits, including entry index bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_CA_CONSTMASK		0	/* constant CA bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_ASID_RESET		0	/* 1 if ASID reset values defined (and all writable); 0 otherwise */
+#define XCHAL_ITLB_SET0_VPN_RESET		0	/* 1 if VPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_ITLB_SET0_PPN_RESET		0	/* 1 if PPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_ITLB_SET0_CA_RESET		1	/* 1 if CA reset values defined (and all writable); 0 otherwise */
+/*  Constant VPN values for each entry of ITLB way set 0 (because VPN_CONSTMASK is non-zero):  */
+#define XCHAL_ITLB_SET0_E0_VPN_CONST		0x00000000
+#define XCHAL_ITLB_SET0_E1_VPN_CONST		0x20000000
+#define XCHAL_ITLB_SET0_E2_VPN_CONST		0x40000000
+#define XCHAL_ITLB_SET0_E3_VPN_CONST		0x60000000
+#define XCHAL_ITLB_SET0_E4_VPN_CONST		0x80000000
+#define XCHAL_ITLB_SET0_E5_VPN_CONST		0xA0000000
+#define XCHAL_ITLB_SET0_E6_VPN_CONST		0xC0000000
+#define XCHAL_ITLB_SET0_E7_VPN_CONST		0xE0000000
+/*  Constant PPN values for each entry of ITLB way set 0 (because PPN_CONSTMASK is non-zero):  */
+#define XCHAL_ITLB_SET0_E0_PPN_CONST		0x00000000
+#define XCHAL_ITLB_SET0_E1_PPN_CONST		0x20000000
+#define XCHAL_ITLB_SET0_E2_PPN_CONST		0x40000000
+#define XCHAL_ITLB_SET0_E3_PPN_CONST		0x60000000
+#define XCHAL_ITLB_SET0_E4_PPN_CONST		0x80000000
+#define XCHAL_ITLB_SET0_E5_PPN_CONST		0xA0000000
+#define XCHAL_ITLB_SET0_E6_PPN_CONST		0xC0000000
+#define XCHAL_ITLB_SET0_E7_PPN_CONST		0xE0000000
+/*  Reset CA values for each entry of ITLB way set 0 (because SET0_CA_RESET is non-zero):  */
+#define XCHAL_ITLB_SET0_E0_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E1_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E2_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E3_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E4_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E5_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E6_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E7_CA_RESET		0x02
+
+
+/***  Data TLB:  ***/
+
+#define XCHAL_DTLB_WAY_BITS		0	/* number of bits holding the ways */
+#define XCHAL_DTLB_WAYS			1	/* number of ways (n-way set-associative TLB) */
+#define XCHAL_DTLB_ARF_WAYS		0	/* number of auto-refill ways */
+#define XCHAL_DTLB_SETS			1	/* number of sets (groups of ways with identical settings) */
+
+/*  Way set to which each way belongs:  */
+#define XCHAL_DTLB_WAY0_SET		0
+
+/*  Ways sets that are used by hardware auto-refill (ARF):  */
+#define XCHAL_DTLB_ARF_SETS		0	/* number of auto-refill sets */
+
+/*  Way sets that are "min-wired" (see terminology comment above):  */
+#define XCHAL_DTLB_MINWIRED_SETS	0	/* number of "min-wired" sets */
+
+
+/*  DTLB way set 0 (group of ways 0 thru 0):  */
+#define XCHAL_DTLB_SET0_WAY			0	/* index of first way in this way set */
+#define XCHAL_DTLB_SET0_WAYS			1	/* number of (contiguous) ways in this way set */
+#define XCHAL_DTLB_SET0_ENTRIES_LOG2		3	/* log2(number of entries in this way) */
+#define XCHAL_DTLB_SET0_ENTRIES			8	/* number of entries in this way (always a power of 2) */
+#define XCHAL_DTLB_SET0_ARF			0	/* 1=autorefill by h/w, 0=non-autorefill (wired/constant/static) */
+#define XCHAL_DTLB_SET0_PAGESIZES		1	/* number of supported page sizes in this way */
+#define XCHAL_DTLB_SET0_PAGESZ_BITS		0	/* number of bits to encode the page size */
+#define XCHAL_DTLB_SET0_PAGESZ_LOG2_MIN		29	/* log2(minimum supported page size) */
+#define XCHAL_DTLB_SET0_PAGESZ_LOG2_MAX		29	/* log2(maximum supported page size) */
+#define XCHAL_DTLB_SET0_PAGESZ_LOG2_LIST	29	/* list of log2(page size)s, separated by XCHAL_SEP;
+							   2^PAGESZ_BITS entries in list, unsupported entries are zero */
+#define XCHAL_DTLB_SET0_ASID_CONSTMASK		0	/* constant ASID bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_VPN_CONSTMASK		0x00000000	/* constant VPN bits, not including entry index bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_PPN_CONSTMASK		0xE0000000	/* constant PPN bits, including entry index bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_CA_CONSTMASK		0	/* constant CA bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_ASID_RESET		0	/* 1 if ASID reset values defined (and all writable); 0 otherwise */
+#define XCHAL_DTLB_SET0_VPN_RESET		0	/* 1 if VPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_DTLB_SET0_PPN_RESET		0	/* 1 if PPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_DTLB_SET0_CA_RESET		1	/* 1 if CA reset values defined (and all writable); 0 otherwise */
+/*  Constant VPN values for each entry of DTLB way set 0 (because VPN_CONSTMASK is non-zero):  */
+#define XCHAL_DTLB_SET0_E0_VPN_CONST		0x00000000
+#define XCHAL_DTLB_SET0_E1_VPN_CONST		0x20000000
+#define XCHAL_DTLB_SET0_E2_VPN_CONST		0x40000000
+#define XCHAL_DTLB_SET0_E3_VPN_CONST		0x60000000
+#define XCHAL_DTLB_SET0_E4_VPN_CONST		0x80000000
+#define XCHAL_DTLB_SET0_E5_VPN_CONST		0xA0000000
+#define XCHAL_DTLB_SET0_E6_VPN_CONST		0xC0000000
+#define XCHAL_DTLB_SET0_E7_VPN_CONST		0xE0000000
+/*  Constant PPN values for each entry of DTLB way set 0 (because PPN_CONSTMASK is non-zero):  */
+#define XCHAL_DTLB_SET0_E0_PPN_CONST		0x00000000
+#define XCHAL_DTLB_SET0_E1_PPN_CONST		0x20000000
+#define XCHAL_DTLB_SET0_E2_PPN_CONST		0x40000000
+#define XCHAL_DTLB_SET0_E3_PPN_CONST		0x60000000
+#define XCHAL_DTLB_SET0_E4_PPN_CONST		0x80000000
+#define XCHAL_DTLB_SET0_E5_PPN_CONST		0xA0000000
+#define XCHAL_DTLB_SET0_E6_PPN_CONST		0xC0000000
+#define XCHAL_DTLB_SET0_E7_PPN_CONST		0xE0000000
+/*  Reset CA values for each entry of DTLB way set 0 (because SET0_CA_RESET is non-zero):  */
+#define XCHAL_DTLB_SET0_E0_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E1_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E2_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E3_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E4_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E5_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E6_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E7_CA_RESET		0x02
+
+
+
+
+#endif /*XTENSA_CONFIG_CORE_MATMAP_H*/
+

--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/defs.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/defs.h
@@ -1,0 +1,38 @@
+/* Definitions for Xtensa instructions, types, and protos. */
+
+/* Copyright (c) 2003-2004 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* NOTE: This file exists only for backward compatibility with T1050
+   and earlier Xtensa releases.  It includes only a subset of the
+   available header files.  */
+
+#ifndef _XTENSA_BASE_HEADER
+#define _XTENSA_BASE_HEADER
+
+#ifdef __XTENSA__
+
+#include <xtensa/tie/xt_core.h>
+#include <xtensa/tie/xt_misc.h>
+#include <xtensa/tie/xt_booleans.h>
+
+#endif /* __XTENSA__ */
+#endif /* !_XTENSA_BASE_HEADER */

--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/secure.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/secure.h
@@ -1,0 +1,45 @@
+
+/* Secure Mode defines. */
+
+/* Copyright (c) 2020 Cadence Design Systems, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef XTENSA_SECURE_H
+#define XTENSA_SECURE_H
+
+
+/* SRAM */
+#define XCHAL_HAVE_SECURE_SRAM	0
+
+/* INSTRAM0 */
+#define XCHAL_HAVE_SECURE_INSTRAM0	0
+
+/* DATARAM0 */
+#define XCHAL_HAVE_SECURE_DATARAM0	0
+
+/* Array of all secure regions' start/size */
+#define XCHAL_SECURE_MEM_LIST \
+{ \
+}
+
+#endif /* XTENSA_SECURE_H */
+

--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/specreg.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/specreg.h
@@ -1,0 +1,110 @@
+/*
+ * Xtensa Special Register symbolic names
+ */
+
+/* $Id: //depot/rel/Homewood/ib.8/Xtensa/SWConfig/hal/specreg.h.tpp#1 $ */
+
+/* Copyright (c) 1998-2002 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef XTENSA_SPECREG_H
+#define XTENSA_SPECREG_H
+
+/*  Include these special register bitfield definitions, for historical reasons:  */
+#include <xtensa/corebits.h>
+
+
+/*  Special registers:  */
+#define LBEG		0
+#define LEND		1
+#define LCOUNT		2
+#define SAR		3
+#define BR		4
+#define SCOMPARE1	12
+#define ACCLO		16
+#define ACCHI		17
+#define MR_0		32
+#define MR_1		33
+#define MR_2		34
+#define MR_3		35
+#define PREFCTL		40
+#define WINDOWBASE	72
+#define WINDOWSTART	73
+#define IBREAKENABLE	96
+#define MEMCTL		97
+#define ATOMCTL		99
+#define DDR		104
+#define IBREAKA_0	128
+#define IBREAKA_1	129
+#define DBREAKA_0	144
+#define DBREAKA_1	145
+#define DBREAKC_0	160
+#define DBREAKC_1	161
+#define EPC_1		177
+#define EPC_2		178
+#define EPC_3		179
+#define EPC_4		180
+#define EPC_5		181
+#define DEPC		192
+#define EPS_2		194
+#define EPS_3		195
+#define EPS_4		196
+#define EPS_5		197
+#define EXCSAVE_1	209
+#define EXCSAVE_2	210
+#define EXCSAVE_3	211
+#define EXCSAVE_4	212
+#define EXCSAVE_5	213
+#define CPENABLE	224
+#define INTERRUPT	226
+#define INTENABLE	228
+#define PS		230
+#define VECBASE		231
+#define EXCCAUSE	232
+#define DEBUGCAUSE	233
+#define CCOUNT		234
+#define PRID		235
+#define ICOUNT		236
+#define ICOUNTLEVEL	237
+#define EXCVADDR	238
+#define CCOMPARE_0	240
+#define CCOMPARE_1	241
+#define MISC_REG_0	244
+#define MISC_REG_1	245
+
+
+/*  Special cases (bases of special register series):  */
+#define MR		32
+#define IBREAKA		128
+#define DBREAKA		144
+#define DBREAKC		160
+#define EPC		176
+#define EPS		192
+#define EXCSAVE		208
+#define CCOMPARE	240
+
+/*  Special names for read-only and write-only interrupt registers:  */
+#define INTREAD		226
+#define INTSET		226
+#define INTCLEAR	227
+
+#endif /* XTENSA_SPECREG_H */
+

--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/system.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/system.h
@@ -1,0 +1,252 @@
+/* 
+ * xtensa/config/system.h -- HAL definitions that are dependent on SYSTEM configuration
+ *
+ *  NOTE: The location and contents of this file are highly subject to change.
+ *
+ *  Source for configuration-independent binaries (which link in a
+ *  configuration-specific HAL library) must NEVER include this file.
+ *  The HAL itself has historically included this file in some instances,
+ *  but this is not appropriate either, because the HAL is meant to be
+ *  core-specific but system independent.
+ */
+
+/* Copyright (c) 2000-2010 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+
+#ifndef XTENSA_CONFIG_SYSTEM_H
+#define XTENSA_CONFIG_SYSTEM_H
+
+
+/*----------------------------------------------------------------------
+				CONFIGURED SOFTWARE OPTIONS
+  ----------------------------------------------------------------------*/
+
+#define XSHAL_USE_ABSOLUTE_LITERALS	0	/* (sw-only option, whether software uses absolute literals) */
+#define XSHAL_HAVE_TEXT_SECTION_LITERALS 1 /* Set if there is some memory that allows both code and literals.  */
+
+#define XSHAL_ABI			XTHAL_ABI_WINDOWED	/* (sw-only option, selected ABI) */
+/*  The above maps to one of the following constants:  */
+#define XTHAL_ABI_WINDOWED		0
+#define XTHAL_ABI_CALL0			1
+
+#define XSHAL_CLIB			XTHAL_CLIB_NEWLIB	/* (sw-only option, selected C library) */
+/*  The above maps to one of the following constants:  */
+#define XTHAL_CLIB_NEWLIB		0
+#define XTHAL_CLIB_UCLIBC		1
+#define XTHAL_CLIB_XCLIB		2
+
+#define XSHAL_USE_FLOATING_POINT	1
+
+#define XSHAL_FLOATING_POINT_ABI        1
+
+/*  SW workarounds enabled for HW errata:  */
+
+/*----------------------------------------------------------------------
+				DEVICE ADDRESSES
+  ----------------------------------------------------------------------*/
+
+/*
+ *  Strange place to find these, but the configuration GUI
+ *  allows moving these around to account for various core
+ *  configurations.  Specific boards (and their BSP software)
+ *  will have specific meanings for these components.
+ */
+
+/*  I/O Block areas:  */
+#define XSHAL_IOBLOCK_CACHED_VADDR	0x70000000
+#define XSHAL_IOBLOCK_CACHED_PADDR	0x70000000
+#define XSHAL_IOBLOCK_CACHED_SIZE	0x0E000000
+
+#define XSHAL_IOBLOCK_BYPASS_VADDR	0x90000000
+#define XSHAL_IOBLOCK_BYPASS_PADDR	0x90000000
+#define XSHAL_IOBLOCK_BYPASS_SIZE	0x0E000000
+
+/*  System ROM:  */
+
+/*  System RAM:  */
+#define XSHAL_RAM_VADDR		0x00000000
+#define XSHAL_RAM_PADDR		0x00000000
+#define XSHAL_RAM_VSIZE		0x24000000
+#define XSHAL_RAM_PSIZE		0x24000000
+#define XSHAL_RAM_SIZE		XSHAL_RAM_PSIZE
+/*  Largest available area (free of vectors):  */
+#define XSHAL_RAM_AVAIL_VADDR	0x00000000
+#define XSHAL_RAM_AVAIL_VSIZE	0x24000000
+
+/*
+ *  Shadow system RAM (same device as system RAM, at different address).
+ *  (Emulation boards need this for the SONIC Ethernet driver
+ *   when data caches are configured for writeback mode.)
+ *  NOTE: on full MMU configs, this points to the BYPASS virtual address
+ *  of system RAM, ie. is the same as XSHAL_RAM_* except that virtual
+ *  addresses are viewed through the BYPASS static map rather than
+ *  the CACHED static map.
+ */
+#define XSHAL_RAM_BYPASS_VADDR		0x40000000
+#define XSHAL_RAM_BYPASS_PADDR		0x40000000
+#define XSHAL_RAM_BYPASS_PSIZE		0x20000000
+
+/*  Alternate system RAM (different device than system RAM):  */
+
+/*  Some available location in which to place devices in a simulation (eg. XTMP):  */
+#define XSHAL_SIMIO_CACHED_VADDR	0xC0000000
+#define XSHAL_SIMIO_BYPASS_VADDR	0xC0000000
+#define XSHAL_SIMIO_PADDR		0xC0000000
+#define XSHAL_SIMIO_SIZE		0x20000000
+
+
+/*----------------------------------------------------------------------
+ *  For use by reference testbench exit and diagnostic routines.
+ */
+#define XSHAL_MAGIC_EXIT		0x60000000
+#define XSHAL_STL_INFO_LOCATION		0x9ffffffc
+
+/*----------------------------------------------------------------------
+ *			DEVICE-ADDRESS DEPENDENT...
+ *
+ *  Values written to CACHEATTR special register (or its equivalent)
+ *  to enable and disable caches in various modes.
+ *----------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------
+			BACKWARD COMPATIBILITY ...
+  ----------------------------------------------------------------------*/
+
+/*
+ *  NOTE:  the following two macros are DEPRECATED.  Use the latter
+ *  board-specific macros instead, which are specially tuned for the
+ *  particular target environments' memory maps.
+ */
+#define XSHAL_CACHEATTR_BYPASS		XSHAL_XT2000_CACHEATTR_BYPASS	/* disable caches in bypass mode */
+#define XSHAL_CACHEATTR_DEFAULT		XSHAL_XT2000_CACHEATTR_DEFAULT	/* default setting to enable caches (no writeback!) */
+
+/*----------------------------------------------------------------------
+				GENERIC
+  ----------------------------------------------------------------------*/
+
+/*  For the following, a 512MB region is used if it contains a system (PIF) RAM,
+ *  system (PIF) ROM, local memory, or XLMI.  */
+
+/*  These set any unused 512MB region to cache-BYPASS attribute:  */
+#define XSHAL_ALLVALID_CACHEATTR_WRITEBACK	0x22222244	/* enable caches in write-back mode */
+#define XSHAL_ALLVALID_CACHEATTR_WRITEALLOC	0x22222211	/* enable caches in write-allocate mode */
+#define XSHAL_ALLVALID_CACHEATTR_WRITETHRU	0x22222211	/* enable caches in write-through mode */
+#define XSHAL_ALLVALID_CACHEATTR_BYPASS		0x22222222	/* disable caches in bypass mode */
+#define XSHAL_ALLVALID_CACHEATTR_DEFAULT	XSHAL_ALLVALID_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*  These set any unused 512MB region to ILLEGAL attribute:  */
+#define XSHAL_STRICT_CACHEATTR_WRITEBACK	0xFFFFFF44	/* enable caches in write-back mode */
+#define XSHAL_STRICT_CACHEATTR_WRITEALLOC	0xFFFFFF11	/* enable caches in write-allocate mode */
+#define XSHAL_STRICT_CACHEATTR_WRITETHRU	0xFFFFFF11	/* enable caches in write-through mode */
+#define XSHAL_STRICT_CACHEATTR_BYPASS		0xFFFFFF22	/* disable caches in bypass mode */
+#define XSHAL_STRICT_CACHEATTR_DEFAULT		XSHAL_STRICT_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*  These set the first 512MB, if unused, to ILLEGAL attribute to help catch
+ *  NULL-pointer dereference bugs; all other unused 512MB regions are set
+ *  to cache-BYPASS attribute:  */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITEBACK	0x22222244	/* enable caches in write-back mode */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITEALLOC	0x22222211	/* enable caches in write-allocate mode */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITETHRU	0x22222211	/* enable caches in write-through mode */
+#define XSHAL_TRAPNULL_CACHEATTR_BYPASS		0x22222222	/* disable caches in bypass mode */
+#define XSHAL_TRAPNULL_CACHEATTR_DEFAULT	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*----------------------------------------------------------------------
+			ISS (Instruction Set Simulator) SPECIFIC ...
+  ----------------------------------------------------------------------*/
+
+/*  For now, ISS defaults to the TRAPNULL settings:  */
+#define XSHAL_ISS_CACHEATTR_WRITEBACK	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK
+#define XSHAL_ISS_CACHEATTR_WRITEALLOC	XSHAL_TRAPNULL_CACHEATTR_WRITEALLOC
+#define XSHAL_ISS_CACHEATTR_WRITETHRU	XSHAL_TRAPNULL_CACHEATTR_WRITETHRU
+#define XSHAL_ISS_CACHEATTR_BYPASS	XSHAL_TRAPNULL_CACHEATTR_BYPASS
+#define XSHAL_ISS_CACHEATTR_DEFAULT	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK
+
+#define XSHAL_ISS_PIPE_REGIONS	0
+#define XSHAL_ISS_SDRAM_REGIONS	0
+
+
+/*----------------------------------------------------------------------
+			XT2000 BOARD SPECIFIC ...
+  ----------------------------------------------------------------------*/
+
+/*  For the following, a 512MB region is used if it contains any system RAM,
+ *  system ROM, local memory, XLMI, or other XT2000 board device or memory.
+ *  Regions containing devices are forced to cache-BYPASS mode regardless
+ *  of whether the macro is _WRITEBACK vs. _BYPASS etc.  */
+
+/*  These set any 512MB region unused on the XT2000 to ILLEGAL attribute:  */
+#define XSHAL_XT2000_CACHEATTR_WRITEBACK	0xFFF24244	/* enable caches in write-back mode */
+#define XSHAL_XT2000_CACHEATTR_WRITEALLOC	0xFFF21211	/* enable caches in write-allocate mode */
+#define XSHAL_XT2000_CACHEATTR_WRITETHRU	0xFFF21211	/* enable caches in write-through mode */
+#define XSHAL_XT2000_CACHEATTR_BYPASS		0xFFF22222	/* disable caches in bypass mode */
+#define XSHAL_XT2000_CACHEATTR_DEFAULT		XSHAL_XT2000_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+#define XSHAL_XT2000_PIPE_REGIONS	0x00000000	/* BusInt pipeline regions */
+#define XSHAL_XT2000_SDRAM_REGIONS	0x00000011	/* BusInt SDRAM regions */
+
+
+/*----------------------------------------------------------------------
+				VECTOR INFO AND SIZES
+  ----------------------------------------------------------------------*/
+
+#define XSHAL_VECTORS_PACKED		0	/* UNUSED */
+#define XSHAL_STATIC_VECTOR_SELECT	0
+#define XSHAL_RESET_VECTOR_VADDR	0x24020000
+#define XSHAL_RESET_VECTOR_PADDR	0x24020000
+
+/*
+ *  Sizes allocated to vectors by the system (memory map) configuration.
+ *  These sizes are constrained by core configuration (eg. one vector's
+ *  code cannot overflow into another vector) but are dependent on the
+ *  system or board (or LSP) memory map configuration.
+ *
+ *  Whether or not each vector happens to be in a system ROM is also
+ *  a system configuration matter, sometimes useful, included here also:
+ */
+#define XSHAL_RESET_VECTOR_SIZE	0x000002E0
+#define XSHAL_RESET_VECTOR_ISROM	0
+#define XSHAL_USER_VECTOR_SIZE	0x0000001C
+#define XSHAL_USER_VECTOR_ISROM	0
+#define XSHAL_PROGRAMEXC_VECTOR_SIZE	XSHAL_USER_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_USEREXC_VECTOR_SIZE	XSHAL_USER_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_KERNEL_VECTOR_SIZE	0x0000001C
+#define XSHAL_KERNEL_VECTOR_ISROM	0
+#define XSHAL_STACKEDEXC_VECTOR_SIZE	XSHAL_KERNEL_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_KERNELEXC_VECTOR_SIZE	XSHAL_KERNEL_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_DOUBLEEXC_VECTOR_SIZE	0x0000001C
+#define XSHAL_DOUBLEEXC_VECTOR_ISROM	0
+#define XSHAL_WINDOW_VECTORS_SIZE	0x00000178
+#define XSHAL_WINDOW_VECTORS_ISROM	0
+#define XSHAL_INTLEVEL2_VECTOR_SIZE	0x0000001C
+#define XSHAL_INTLEVEL2_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL3_VECTOR_SIZE	0x0000001C
+#define XSHAL_INTLEVEL3_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL4_VECTOR_SIZE	0x0000001C
+#define XSHAL_INTLEVEL4_VECTOR_ISROM	0
+#define XSHAL_DEBUG_VECTOR_SIZE		XSHAL_INTLEVEL4_VECTOR_SIZE
+#define XSHAL_DEBUG_VECTOR_ISROM	XSHAL_INTLEVEL4_VECTOR_ISROM
+#define XSHAL_NMI_VECTOR_SIZE	0x0000001C
+#define XSHAL_NMI_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL5_VECTOR_SIZE	XSHAL_NMI_VECTOR_SIZE
+
+#endif /*XTENSA_CONFIG_SYSTEM_H*/
+

--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/tie-asm.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/tie-asm.h
@@ -1,0 +1,387 @@
+/* 
+ * tie-asm.h -- compile-time HAL assembler definitions dependent on CORE & TIE
+ *
+ *  NOTE:  This header file is not meant to be included directly.
+ */
+
+/* This header file contains assembly-language definitions (assembly
+   macros, etc.) for this specific Xtensa processor's TIE extensions
+   and options.  It is customized to this Xtensa processor configuration.
+
+   Copyright (c) 1999-2022 Cadence Design Systems Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef _XTENSA_CORE_TIE_ASM_H
+#define _XTENSA_CORE_TIE_ASM_H
+
+#define XT_ADDI_A 1
+#include <xtensa/coreasm.h>
+
+/*  Selection parameter values for save-area save/restore macros:  */
+/*  Option vs. TIE:  */
+#define XTHAL_SAS_TIE	0x0001	/* custom extension or coprocessor */
+#define XTHAL_SAS_OPT	0x0002	/* optional (and not a coprocessor) */
+#define XTHAL_SAS_ANYOT	0x0003	/* both of the above */
+/*  Whether used automatically by compiler:  */
+#define XTHAL_SAS_NOCC	0x0004	/* not used by compiler w/o special opts/code */
+#define XTHAL_SAS_CC	0x0008	/* used by compiler without special opts/code */
+#define XTHAL_SAS_ANYCC	0x000C	/* both of the above */
+/*  ABI handling across function calls:  */
+#define XTHAL_SAS_CALR	0x0010	/* caller-saved */
+#define XTHAL_SAS_CALE	0x0020	/* callee-saved */
+#define XTHAL_SAS_GLOB	0x0040	/* global across function calls (in thread) */
+#define XTHAL_SAS_ANYABI	0x0070	/* all of the above three */
+/*  Misc  */
+#define XTHAL_SAS_ALL	0xFFFF	/* include all default NCP contents */
+#define XTHAL_SAS3(optie,ccuse,abi)	( ((optie) & XTHAL_SAS_ANYOT)  \
+					| ((ccuse) & XTHAL_SAS_ANYCC)  \
+					| ((abi)   & XTHAL_SAS_ANYABI) )
+
+
+    /*
+      *  Macro to store all non-coprocessor (extra) custom TIE and optional state
+      *  (not including zero-overhead loop registers).
+      *  Required parameters:
+      *      ptr         Save area pointer address register (clobbered)
+      *                  (register must contain a 4 byte aligned address).
+      *      at1..at4    Four temporary address registers (first XCHAL_NCP_NUM_ATMPS
+      *                  registers are clobbered, the remaining are unused).
+      *  Optional parameters:
+      *      continue    If macro invoked as part of a larger store sequence, set to 1
+      *                  if this is not the first in the sequence.  Defaults to 0.
+      *      ofs         Offset from start of larger sequence (from value of first ptr
+      *                  in sequence) at which to store.  Defaults to next available space
+      *                  (or 0 if <continue> is 0).
+      *      select      Select what category(ies) of registers to store, as a bitmask
+      *                  (see XTHAL_SAS_xxx constants).  Defaults to all registers.
+      *      alloc       Select what category(ies) of registers to allocate; if any
+      *                  category is selected here that is not in <select>, space for
+      *                  the corresponding registers is skipped without doing any store.
+      */
+    .macro xchal_ncp_store  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start	\continue, \ofs
+	// Optional global registers used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	rur.threadptr	\at1		// threadptr option
+	s32i	\at1, \ptr, .Lxchal_ofs_+0
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.endif
+	// Optional caller-saved registers used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	rsr.acclo	\at1		// MAC16 option
+	s32i	\at1, \ptr, .Lxchal_ofs_+0
+	rsr.acchi	\at1		// MAC16 option
+	s32i	\at1, \ptr, .Lxchal_ofs_+4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.endif
+	// Optional caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 996, 4, 4
+	rsr.br	\at1		// boolean option
+	s32i	\at1, \ptr, .Lxchal_ofs_+0
+	rsr.scompare1	\at1		// conditional store option
+	s32i	\at1, \ptr, .Lxchal_ofs_+4
+	rsr.m0	\at1		// MAC16 option
+	s32i	\at1, \ptr, .Lxchal_ofs_+8
+	rsr.m1	\at1		// MAC16 option
+	s32i	\at1, \ptr, .Lxchal_ofs_+12
+	rsr.m2	\at1		// MAC16 option
+	s32i	\at1, \ptr, .Lxchal_ofs_+16
+	rsr.m3	\at1		// MAC16 option
+	s32i	\at1, \ptr, .Lxchal_ofs_+20
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 24
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 996, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 24
+	.endif
+	// Custom caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1008, 4, 4
+	rur.f64r_lo	\at1		// ureg 234
+	s32i	\at1, \ptr, .Lxchal_ofs_+0
+	rur.f64r_hi	\at1		// ureg 235
+	s32i	\at1, \ptr, .Lxchal_ofs_+4
+	rur.f64s	\at1		// ureg 236
+	s32i	\at1, \ptr, .Lxchal_ofs_+8
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 12
+	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1008, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 12
+	.endif
+    .endm	// xchal_ncp_store
+
+    /*
+      *  Macro to load all non-coprocessor (extra) custom TIE and optional state
+      *  (not including zero-overhead loop registers).
+      *  Required parameters:
+      *      ptr         Save area pointer address register (clobbered)
+      *                  (register must contain a 4 byte aligned address).
+      *      at1..at4    Four temporary address registers (first XCHAL_NCP_NUM_ATMPS
+      *                  registers are clobbered, the remaining are unused).
+      *  Optional parameters:
+      *      continue    If macro invoked as part of a larger load sequence, set to 1
+      *                  if this is not the first in the sequence.  Defaults to 0.
+      *      ofs         Offset from start of larger sequence (from value of first ptr
+      *                  in sequence) at which to load.  Defaults to next available space
+      *                  (or 0 if <continue> is 0).
+      *      select      Select what category(ies) of registers to load, as a bitmask
+      *                  (see XTHAL_SAS_xxx constants).  Defaults to all registers.
+      *      alloc       Select what category(ies) of registers to allocate; if any
+      *                  category is selected here that is not in <select>, space for
+      *                  the corresponding registers is skipped without doing any load.
+      */
+    .macro xchal_ncp_load  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start	\continue, \ofs
+	// Optional global registers used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	l32i	\at1, \ptr, .Lxchal_ofs_+0
+	wur.threadptr	\at1		// threadptr option
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.endif
+	// Optional caller-saved registers used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	l32i	\at1, \ptr, .Lxchal_ofs_+0
+	wsr.acclo	\at1		// MAC16 option
+	l32i	\at1, \ptr, .Lxchal_ofs_+4
+	wsr.acchi	\at1		// MAC16 option
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.endif
+	// Optional caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 996, 4, 4
+	l32i	\at1, \ptr, .Lxchal_ofs_+0
+	wsr.br	\at1		// boolean option
+	l32i	\at1, \ptr, .Lxchal_ofs_+4
+	wsr.scompare1	\at1		// conditional store option
+	l32i	\at1, \ptr, .Lxchal_ofs_+8
+	wsr.m0	\at1		// MAC16 option
+	l32i	\at1, \ptr, .Lxchal_ofs_+12
+	wsr.m1	\at1		// MAC16 option
+	l32i	\at1, \ptr, .Lxchal_ofs_+16
+	wsr.m2	\at1		// MAC16 option
+	l32i	\at1, \ptr, .Lxchal_ofs_+20
+	wsr.m3	\at1		// MAC16 option
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 24
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 996, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 24
+	.endif
+	// Custom caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1008, 4, 4
+	l32i	\at1, \ptr, .Lxchal_ofs_+0
+	wur.f64r_lo	\at1		// ureg 234
+	l32i	\at1, \ptr, .Lxchal_ofs_+4
+	wur.f64r_hi	\at1		// ureg 235
+	l32i	\at1, \ptr, .Lxchal_ofs_+8
+	wur.f64s	\at1		// ureg 236
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 12
+	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1008, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 12
+	.endif
+    .endm	// xchal_ncp_load
+
+
+#define XCHAL_NCP_NUM_ATMPS	1
+
+    /* 
+     *  Macro to store the state of TIE coprocessor AudioEngineLX.
+     *  Required parameters:
+     *      ptr         Save area pointer address register (clobbered)
+     *                  (register must contain a 8 byte aligned address).
+     *      at1..at4    Four temporary address registers (first XCHAL_CP1_NUM_ATMPS
+     *                  registers are clobbered, the remaining are unused).
+     *  Optional parameters are the same as for xchal_ncp_store.
+     */
+#define xchal_cp_AudioEngineLX_store	xchal_cp1_store
+    .macro	xchal_cp1_store  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start \continue, \ofs
+	// Custom caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	ae_s64.i	aed0, \ptr, .Lxchal_ofs_+40
+	ae_s64.i	aed1, \ptr, .Lxchal_ofs_+48
+	ae_s64.i	aed2, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_s64.i	aed3, \ptr, .Lxchal_ofs_+0
+	ae_s64.i	aed4, \ptr, .Lxchal_ofs_+8
+	ae_s64.i	aed5, \ptr, .Lxchal_ofs_+16
+	ae_s64.i	aed6, \ptr, .Lxchal_ofs_+24
+	ae_s64.i	aed7, \ptr, .Lxchal_ofs_+32
+	ae_s64.i	aed8, \ptr, .Lxchal_ofs_+40
+	ae_s64.i	aed9, \ptr, .Lxchal_ofs_+48
+	ae_s64.i	aed10, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_s64.i	aed11, \ptr, .Lxchal_ofs_+0
+	ae_s64.i	aed12, \ptr, .Lxchal_ofs_+8
+	ae_s64.i	aed13, \ptr, .Lxchal_ofs_+16
+	ae_s64.i	aed14, \ptr, .Lxchal_ofs_+24
+	ae_s64.i	aed15, \ptr, .Lxchal_ofs_+32
+	ae_movae	\at1, aep0
+	s8i	\at1, \ptr, .Lxchal_ofs_+40
+	ae_movae	\at1, aep1
+	s8i	\at1, \ptr, .Lxchal_ofs_+41
+	ae_movae	\at1, aep2
+	s8i	\at1, \ptr, .Lxchal_ofs_+42
+	ae_movae	\at1, aep3
+	s8i	\at1, \ptr, .Lxchal_ofs_+43
+	ae_salign64.i	u0, \ptr, .Lxchal_ofs_+48
+	ae_salign64.i	u1, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_salign64.i	u2, \ptr, .Lxchal_ofs_+0
+	ae_salign64.i	u3, \ptr, .Lxchal_ofs_+8
+	addi	\ptr, \ptr, -192
+	ae_movvfcrfsr	aed0		// ureg FCR_FSR
+	ae_s64.i	aed0, \ptr, .Lxchal_ofs_+0 + 0
+	rur.ae_ovf_sar	\at1		// ureg 240
+	s32i	\at1, \ptr, .Lxchal_ofs_+8
+	rur.ae_bithead	\at1		// ureg 241
+	s32i	\at1, \ptr, .Lxchal_ofs_+12
+	rur.ae_ts_fts_bu_bp	\at1		// ureg 242
+	s32i	\at1, \ptr, .Lxchal_ofs_+16
+	rur.ae_cw_sd_no	\at1		// ureg 243
+	s32i	\at1, \ptr, .Lxchal_ofs_+20
+	rur.ae_cbegin0	\at1		// ureg 246
+	s32i	\at1, \ptr, .Lxchal_ofs_+24
+	rur.ae_cend0	\at1		// ureg 247
+	s32i	\at1, \ptr, .Lxchal_ofs_+28
+	rur.ae_cbegin1	\at1		// ureg 248
+	s32i	\at1, \ptr, .Lxchal_ofs_+32
+	rur.ae_cend1	\at1		// ureg 249
+	s32i	\at1, \ptr, .Lxchal_ofs_+36
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
+	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
+	.endif
+    .endm	// xchal_cp1_store
+
+    /* 
+     *  Macro to load the state of TIE coprocessor AudioEngineLX.
+     *  Required parameters:
+     *      ptr         Save area pointer address register (clobbered)
+     *                  (register must contain a 8 byte aligned address).
+     *      at1..at4    Four temporary address registers (first XCHAL_CP1_NUM_ATMPS
+     *                  registers are clobbered, the remaining are unused).
+     *  Optional parameters are the same as for xchal_ncp_load.
+     */
+#define xchal_cp_AudioEngineLX_load	xchal_cp1_load
+    .macro	xchal_cp1_load  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start \continue, \ofs
+	// Custom caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	ae_l64.i	aed0, \ptr, .Lxchal_ofs_+0 + 0		// ureg FCR_FSR
+	ae_movfcrfsrv	aed0
+	l32i	\at1, \ptr, .Lxchal_ofs_+8
+	wur.ae_ovf_sar	\at1		// ureg 240
+	l32i	\at1, \ptr, .Lxchal_ofs_+12
+	wur.ae_bithead	\at1		// ureg 241
+	l32i	\at1, \ptr, .Lxchal_ofs_+16
+	wur.ae_ts_fts_bu_bp	\at1		// ureg 242
+	l32i	\at1, \ptr, .Lxchal_ofs_+20
+	wur.ae_cw_sd_no	\at1		// ureg 243
+	l32i	\at1, \ptr, .Lxchal_ofs_+24
+	wur.ae_cbegin0	\at1		// ureg 246
+	l32i	\at1, \ptr, .Lxchal_ofs_+28
+	wur.ae_cend0	\at1		// ureg 247
+	l32i	\at1, \ptr, .Lxchal_ofs_+32
+	wur.ae_cbegin1	\at1		// ureg 248
+	l32i	\at1, \ptr, .Lxchal_ofs_+36
+	wur.ae_cend1	\at1		// ureg 249
+	ae_l64.i	aed0, \ptr, .Lxchal_ofs_+40
+	ae_l64.i	aed1, \ptr, .Lxchal_ofs_+48
+	ae_l64.i	aed2, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_l64.i	aed3, \ptr, .Lxchal_ofs_+0
+	ae_l64.i	aed4, \ptr, .Lxchal_ofs_+8
+	ae_l64.i	aed5, \ptr, .Lxchal_ofs_+16
+	ae_l64.i	aed6, \ptr, .Lxchal_ofs_+24
+	ae_l64.i	aed7, \ptr, .Lxchal_ofs_+32
+	ae_l64.i	aed8, \ptr, .Lxchal_ofs_+40
+	ae_l64.i	aed9, \ptr, .Lxchal_ofs_+48
+	ae_l64.i	aed10, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_l64.i	aed11, \ptr, .Lxchal_ofs_+0
+	ae_l64.i	aed12, \ptr, .Lxchal_ofs_+8
+	ae_l64.i	aed13, \ptr, .Lxchal_ofs_+16
+	ae_l64.i	aed14, \ptr, .Lxchal_ofs_+24
+	ae_l64.i	aed15, \ptr, .Lxchal_ofs_+32
+	addi	\ptr, \ptr, 40
+	l8ui	\at1, \ptr, .Lxchal_ofs_+0
+	ae_movea	aep0, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+1
+	ae_movea	aep1, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+2
+	ae_movea	aep2, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+3
+	ae_movea	aep3, \at1
+	addi	\ptr, \ptr, 8
+	ae_lalign64.i	u0, \ptr, .Lxchal_ofs_+0
+	ae_lalign64.i	u1, \ptr, .Lxchal_ofs_+8
+	ae_lalign64.i	u2, \ptr, .Lxchal_ofs_+16
+	ae_lalign64.i	u3, \ptr, .Lxchal_ofs_+24
+	.set	.Lxchal_pofs_, .Lxchal_pofs_ + 176
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 32
+	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
+	.endif
+    .endm	// xchal_cp1_load
+
+#define XCHAL_CP1_NUM_ATMPS	1
+#define XCHAL_SA_NUM_ATMPS	1
+
+	/*  Empty macros for unconfigured coprocessors:  */
+	.macro xchal_cp0_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp0_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp2_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp2_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp3_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp3_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp4_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp4_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp5_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp5_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp6_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp6_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp7_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp7_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+
+#endif /*_XTENSA_CORE_TIE_ASM_H*/
+

--- a/zephyr/soc/nxp_rt600_adsp/xtensa/config/tie.h
+++ b/zephyr/soc/nxp_rt600_adsp/xtensa/config/tie.h
@@ -1,0 +1,201 @@
+/* 
+ * tie.h -- compile-time HAL definitions dependent on CORE & TIE configuration
+ *
+ *  NOTE:  This header file is not meant to be included directly.
+ */
+
+/* This header file describes this specific Xtensa processor's TIE extensions
+   that extend basic Xtensa core functionality.  It is customized to this
+   Xtensa processor configuration.
+
+   Copyright (c) 1999-2022 Cadence Design Systems Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef XTENSA_CORE_TIE_H
+#define XTENSA_CORE_TIE_H
+
+/* parasoft-begin-suppress ALL "This file not MISRA checked." */
+
+#define XCHAL_CP_NUM			1	/* number of coprocessors */
+#define XCHAL_CP_MAX			2	/* max CP ID + 1 (0 if none) */
+#define XCHAL_CP_MASK			0x02	/* bitmask of all CPs by ID */
+#define XCHAL_CP_PORT_MASK		0x00	/* bitmask of only port CPs */
+
+/*  Basic parameters of each coprocessor:  */
+#define XCHAL_CP1_NAME			"AudioEngineLX"
+#define XCHAL_CP1_IDENT			AudioEngineLX
+#define XCHAL_CP1_SA_SIZE		208	/* size of state save area */
+#define XCHAL_CP1_SA_ALIGN		8	/* min alignment of save area */
+#define XCHAL_CP_ID_AUDIOENGINELX   	1	/* coprocessor ID (0..7) */
+
+/*  Filler info for unassigned coprocessors, to simplify arrays etc:  */
+#define XCHAL_CP0_SA_SIZE		0
+#define XCHAL_CP0_SA_ALIGN		1
+#define XCHAL_CP2_SA_SIZE		0
+#define XCHAL_CP2_SA_ALIGN		1
+#define XCHAL_CP3_SA_SIZE		0
+#define XCHAL_CP3_SA_ALIGN		1
+#define XCHAL_CP4_SA_SIZE		0
+#define XCHAL_CP4_SA_ALIGN		1
+#define XCHAL_CP5_SA_SIZE		0
+#define XCHAL_CP5_SA_ALIGN		1
+#define XCHAL_CP6_SA_SIZE		0
+#define XCHAL_CP6_SA_ALIGN		1
+#define XCHAL_CP7_SA_SIZE		0
+#define XCHAL_CP7_SA_ALIGN		1
+
+/*  Save area for non-coprocessor optional and custom (TIE) state:  */
+#define XCHAL_NCP_SA_SIZE		48
+#define XCHAL_NCP_SA_ALIGN		4
+
+/*  Total save area for optional and custom state (NCP + CPn):  */
+#define XCHAL_TOTAL_SA_SIZE		256	/* with 16-byte align padding */
+#define XCHAL_TOTAL_SA_ALIGN		8	/* actual minimum alignment */
+
+/*
+ * Detailed contents of save areas.
+ * NOTE:  caller must define the XCHAL_SA_REG macro (not defined here)
+ * before expanding the XCHAL_xxx_SA_LIST() macros.
+ *
+ * XCHAL_SA_REG(s,ccused,abikind,kind,opt,name,galign,align,asize,
+ *		dbnum,base,regnum,bitsz,gapsz,reset,x...)
+ *
+ *	s = passed from XCHAL_*_LIST(s), eg. to select how to expand
+ *	ccused = set if used by compiler without special options or code
+ *	abikind = 0 (caller-saved), 1 (callee-saved), or 2 (thread-global)
+ *	kind = 0 (special reg), 1 (TIE user reg), or 2 (TIE regfile reg)
+ *	opt = 0 (custom TIE extension or coprocessor), or 1 (optional reg)
+ *	name = lowercase reg name (no quotes)
+ *	galign = group byte alignment (power of 2) (galign >= align)
+ *	align = register byte alignment (power of 2)
+ *	asize = allocated size in bytes (asize*8 == bitsz + gapsz + padsz)
+ *	  (not including any pad bytes required to galign this or next reg)
+ *	dbnum = unique target number f/debug (see <xtensa-libdb-macros.h>)
+ *	base = reg shortname w/o index (or sr=special, ur=TIE user reg)
+ *	regnum = reg index in regfile, or special/TIE-user reg number
+ *	bitsz = number of significant bits (regfile width, or ur/sr mask bits)
+ *	gapsz = intervening bits, if bitsz bits not stored contiguously
+ *	(padsz = pad bits at end [TIE regfile] or at msbits [ur,sr] of asize)
+ *	reset = register reset value (or 0 if undefined at reset)
+ *	x = reserved for future use (0 until then)
+ *
+ *  To filter out certain registers, e.g. to expand only the non-global
+ *  registers used by the compiler, you can do something like this:
+ *
+ *  #define XCHAL_SA_REG(s,ccused,p...)	SELCC##ccused(p)
+ *  #define SELCC0(p...)
+ *  #define SELCC1(abikind,p...)	SELAK##abikind(p)
+ *  #define SELAK0(p...)		REG(p)
+ *  #define SELAK1(p...)		REG(p)
+ *  #define SELAK2(p...)
+ *  #define REG(kind,tie,name,galn,aln,asz,csz,dbnum,base,rnum,bsz,rst,x...) \
+ *		...what you want to expand...
+ */
+
+#define XCHAL_NCP_SA_NUM	12
+#define XCHAL_NCP_SA_LIST(s)	\
+ XCHAL_SA_REG(s,1,2,1,1,      threadptr, 4, 4, 4,0x03E7,  ur,231, 32,0,0,0) \
+ XCHAL_SA_REG(s,1,0,0,1,          acclo, 4, 4, 4,0x0210,  sr,16 , 32,0,0,0) \
+ XCHAL_SA_REG(s,1,0,0,1,          acchi, 4, 4, 4,0x0211,  sr,17 ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,             br, 4, 4, 4,0x0204,  sr,4  , 16,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,      scompare1, 4, 4, 4,0x020C,  sr,12 , 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,             m0, 4, 4, 4,0x0220,  sr,32 , 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,             m1, 4, 4, 4,0x0221,  sr,33 , 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,             m2, 4, 4, 4,0x0222,  sr,34 , 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,             m3, 4, 4, 4,0x0223,  sr,35 , 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,        f64r_lo, 4, 4, 4,0x03EA,  ur,234, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,        f64r_hi, 4, 4, 4,0x03EB,  ur,235, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,           f64s, 4, 4, 4,0x03EC,  ur,236, 32,0,0,0)
+
+#define XCHAL_CP0_SA_NUM	0
+#define XCHAL_CP0_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP1_SA_NUM	33
+#define XCHAL_CP1_SA_LIST(s)	\
+ XCHAL_SA_REG(s,0,0,1,0,        fcr_fsr, 8, 8, 8,0x1029,  ur,-1 ,  7,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_ovf_sar, 4, 4, 4,0x03F0,  ur,240, 15,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_bithead, 4, 4, 4,0x03F1,  ur,241, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,ae_ts_fts_bu_bp, 4, 4, 4,0x03F2,  ur,242, 16,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,    ae_cw_sd_no, 4, 4, 4,0x03F3,  ur,243, 29,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_cbegin0, 4, 4, 4,0x03F6,  ur,246, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,       ae_cend0, 4, 4, 4,0x03F7,  ur,247, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_cbegin1, 4, 4, 4,0x03F8,  ur,248, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,       ae_cend1, 4, 4, 4,0x03F9,  ur,249, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed0, 8, 8, 8,0x1010, aed,0  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed1, 8, 8, 8,0x1011, aed,1  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed2, 8, 8, 8,0x1012, aed,2  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed3, 8, 8, 8,0x1013, aed,3  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed4, 8, 8, 8,0x1014, aed,4  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed5, 8, 8, 8,0x1015, aed,5  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed6, 8, 8, 8,0x1016, aed,6  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed7, 8, 8, 8,0x1017, aed,7  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed8, 8, 8, 8,0x1018, aed,8  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed9, 8, 8, 8,0x1019, aed,9  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed10, 8, 8, 8,0x101A, aed,10 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed11, 8, 8, 8,0x101B, aed,11 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed12, 8, 8, 8,0x101C, aed,12 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed13, 8, 8, 8,0x101D, aed,13 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed14, 8, 8, 8,0x101E, aed,14 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed15, 8, 8, 8,0x101F, aed,15 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep0, 1, 1, 1,0x1024, aep,0  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep1, 1, 1, 1,0x1025, aep,1  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep2, 1, 1, 1,0x1026, aep,2  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep3, 1, 1, 1,0x1027, aep,3  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u0, 8, 8, 8,0x1020,   u,0  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u1, 8, 8, 8,0x1021,   u,1  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u2, 8, 8, 8,0x1022,   u,2  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u3, 8, 8, 8,0x1023,   u,3  , 64,0,0,0)
+
+#define XCHAL_CP2_SA_NUM	0
+#define XCHAL_CP2_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP3_SA_NUM	0
+#define XCHAL_CP3_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP4_SA_NUM	0
+#define XCHAL_CP4_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP5_SA_NUM	0
+#define XCHAL_CP5_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP6_SA_NUM	0
+#define XCHAL_CP6_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP7_SA_NUM	0
+#define XCHAL_CP7_SA_LIST(s)	/* empty */
+
+/* Byte length of instruction from its first nibble (op0 field), per FLIX.  */
+/* (not available, must use XCHAL_BYTE0_FORMAT_LENGTHS for this processor) */
+/* Byte length of instruction from its first byte, per FLIX.  */
+#define XCHAL_BYTE0_FORMAT_LENGTHS	\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11
+
+/* parasoft-end-suppress ALL "This file not MISRA checked." */
+
+#endif /* XTENSA_CORE_TIE_H */
+


### PR DESCRIPTION
This PR adds an SoC overlay for the HiFi 4 DSP instantiated in NXP's MIMXRT685.