### PR TITLE
zephyr: adding sample_controller32 for MPU

### DIFF
--- a/zephyr/soc/sample_controller32/xtensa/config/core-isa.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/core-isa.h
@@ -1,0 +1,739 @@
+/* 
+ * xtensa/config/core-isa.h -- HAL definitions that are dependent on Xtensa
+ *				processor CORE configuration
+ *
+ *  See <xtensa/config/core.h>, which includes this file, for more details.
+ */
+
+/* Xtensa processor core configuration information.
+
+   Copyright (c) 1999-2019 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef XTENSA_CORE_CONFIGURATION_H_
+#define XTENSA_CORE_CONFIGURATION_H_
+
+//depot/dev/Homewood/Xtensa/SWConfig/hal/core-common.h.tph#24 - edit change 444323 (text+ko)
+
+/****************************************************************************
+	    Parameters Useful for Any Code, USER or PRIVILEGED
+ ****************************************************************************/
+
+/*
+ *  Note:  Macros of the form XCHAL_HAVE_*** have a value of 1 if the option is
+ *  configured, and a value of 0 otherwise.  These macros are always defined.
+ */
+
+
+/*----------------------------------------------------------------------
+				ISA
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_BE			0	/* big-endian byte ordering */
+#define XCHAL_HAVE_WINDOWED		1	/* windowed registers option */
+#define XCHAL_NUM_AREGS			32	/* num of physical addr regs */
+#define XCHAL_NUM_AREGS_LOG2		5	/* log2(XCHAL_NUM_AREGS) */
+#define XCHAL_MAX_INSTRUCTION_SIZE	3	/* max instr bytes (3..8) */
+#define XCHAL_HAVE_DEBUG		1	/* debug option */
+#define XCHAL_HAVE_DENSITY		1	/* 16-bit instructions */
+#define XCHAL_HAVE_LOOPS		0	/* zero-overhead loops */
+#define XCHAL_LOOP_BUFFER_SIZE		0	/* zero-ov. loop instr buffer size */
+#define XCHAL_HAVE_NSA			1	/* NSA/NSAU instructions */
+#define XCHAL_HAVE_MINMAX		1	/* MIN/MAX instructions */
+#define XCHAL_HAVE_SEXT			1	/* SEXT instruction */
+#define XCHAL_HAVE_DEPBITS		0	/* DEPBITS instruction */
+#define XCHAL_HAVE_CLAMPS		0	/* CLAMPS instruction */
+#define XCHAL_HAVE_MUL16		1	/* MUL16S/MUL16U instructions */
+#define XCHAL_HAVE_MUL32		1	/* MULL instruction */
+#define XCHAL_HAVE_MUL32_HIGH		0	/* MULUH/MULSH instructions */
+#define XCHAL_HAVE_DIV32		1	/* QUOS/QUOU/REMS/REMU instructions */
+#define XCHAL_HAVE_L32R			1	/* L32R instruction */
+#define XCHAL_HAVE_ABSOLUTE_LITERALS	0	/* non-PC-rel (extended) L32R */
+#define XCHAL_HAVE_CONST16		0	/* CONST16 instruction */
+#define XCHAL_HAVE_ADDX			1	/* ADDX#/SUBX# instructions */
+#define XCHAL_HAVE_EXCLUSIVE            1	/* L32EX/S32EX instructions */
+#define XCHAL_HAVE_WIDE_BRANCHES	0	/* B*.W18 or B*.W15 instr's */
+#define XCHAL_HAVE_PREDICTED_BRANCHES	0	/* B[EQ/EQZ/NE/NEZ]T instr's */
+#define XCHAL_HAVE_CALL4AND12		1	/* (obsolete option) */
+#define XCHAL_HAVE_ABS			1	/* ABS instruction */
+#define XCHAL_HAVE_RELEASE_SYNC		1	/* L32AI/S32RI instructions */
+#define XCHAL_HAVE_S32C1I		0	/* S32C1I instruction */
+#define XCHAL_HAVE_SPECULATION		0	/* speculation */
+#define XCHAL_HAVE_FULL_RESET		1	/* all regs/state reset */
+#define XCHAL_NUM_CONTEXTS		1	/* */
+#define XCHAL_NUM_MISC_REGS		2	/* num of scratch regs (0..4) */
+#define XCHAL_HAVE_TAP_MASTER		0	/* JTAG TAP control instr's */
+#define XCHAL_HAVE_PRID			1	/* processor ID register */
+#define XCHAL_HAVE_EXTERN_REGS		1	/* WER/RER instructions */
+#define XCHAL_HAVE_MX			0	/* MX core (Tensilica internal) */
+#define XCHAL_HAVE_MP_INTERRUPTS	0	/* interrupt distributor port */
+#define XCHAL_HAVE_MP_RUNSTALL		0	/* core RunStall control port */
+#define XCHAL_HAVE_PSO			0	/* Power Shut-Off */
+#define XCHAL_HAVE_PSO_CDM		0	/* core/debug/mem pwr domains */
+#define XCHAL_HAVE_PSO_FULL_RETENTION	0	/* all regs preserved on PSO */
+#define XCHAL_HAVE_THREADPTR		0	/* THREADPTR register */
+#define XCHAL_HAVE_BOOLEANS		0	/* boolean registers */
+#define XCHAL_HAVE_CP			0	/* CPENABLE reg (coprocessor) */
+#define XCHAL_CP_MAXCFG			0	/* max allowed cp id plus one */
+#define XCHAL_HAVE_MAC16		0	/* MAC16 package */
+#define XCHAL_HAVE_LX			1	/* LX core */
+#define XCHAL_HAVE_NX			0	/* NX core (starting RH) */
+
+#define XCHAL_HAVE_SUPERGATHER		0	/* SuperGather */
+
+#define XCHAL_HAVE_FUSION		0	/* Fusion*/
+#define XCHAL_HAVE_FUSION_FP		0	/* Fusion FP option */
+#define XCHAL_HAVE_FUSION_LOW_POWER	0	/* Fusion Low Power option */
+#define XCHAL_HAVE_FUSION_AES		0	/* Fusion BLE/Wifi AES-128 CCM option */
+#define XCHAL_HAVE_FUSION_CONVENC	0	/* Fusion Conv Encode option */
+#define XCHAL_HAVE_FUSION_LFSR_CRC	0	/* Fusion LFSR-CRC option */
+#define XCHAL_HAVE_FUSION_BITOPS	0	/* Fusion Bit Operations Support option */
+#define XCHAL_HAVE_FUSION_AVS		0	/* Fusion AVS option */
+#define XCHAL_HAVE_FUSION_16BIT_BASEBAND 0	/* Fusion 16-bit Baseband option */
+#define XCHAL_HAVE_FUSION_VITERBI	0	/* Fusion Viterbi option */
+#define XCHAL_HAVE_FUSION_SOFTDEMAP	0	/* Fusion Soft Bit Demap option */
+#define XCHAL_HAVE_HIFIPRO		0	/* HiFiPro Audio Engine pkg */
+#define XCHAL_HAVE_HIFI5		0	/* HiFi5 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI5_NN_MAC		0	/* HiFi5 Audio Engine NN-MAC option */
+#define XCHAL_HAVE_HIFI5_VFPU		0	/* HiFi5 Audio Engine Single-Precision VFPU option */
+#define XCHAL_HAVE_HIFI5_HP_VFPU	0	/* HiFi5 Audio Engine Half-Precision VFPU option */
+#define XCHAL_HAVE_HIFI4		0	/* HiFi4 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI4_VFPU		0	/* HiFi4 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI3		0	/* HiFi3 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI3_VFPU		0	/* HiFi3 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI3Z		0	/* HiFi3Z Audio Engine pkg */
+#define XCHAL_HAVE_HIFI3Z_VFPU	0	/* HiFi3Z Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI2		0	/* HiFi2 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI2EP		0	/* HiFi2EP */
+#define XCHAL_HAVE_HIFI_MINI		0	
+
+
+
+#define XCHAL_HAVE_VECTORFPU2005	0	/* vector floating-point pkg */
+#define XCHAL_HAVE_USER_DPFPU		0       /* user DP floating-point pkg */
+#define XCHAL_HAVE_USER_SPFPU		0       /* user SP floating-point pkg */
+#define XCHAL_HAVE_FP			0	/* single prec floating point */
+#define XCHAL_HAVE_FP_DIV		0	/* FP with DIV instructions */
+#define XCHAL_HAVE_FP_RECIP		0	/* FP with RECIP instructions */
+#define XCHAL_HAVE_FP_SQRT		0	/* FP with SQRT instructions */
+#define XCHAL_HAVE_FP_RSQRT		0	/* FP with RSQRT instructions */
+#define XCHAL_HAVE_DFP			0	/* double precision FP pkg */
+#define XCHAL_HAVE_DFP_DIV		0	/* DFP with DIV instructions */
+#define XCHAL_HAVE_DFP_RECIP		0	/* DFP with RECIP instructions*/
+#define XCHAL_HAVE_DFP_SQRT		0	/* DFP with SQRT instructions */
+#define XCHAL_HAVE_DFP_RSQRT		0	/* DFP with RSQRT instructions*/
+#define XCHAL_HAVE_DFP_ACCEL		0	/* double precision FP acceleration pkg */
+#define XCHAL_HAVE_DFP_accel		XCHAL_HAVE_DFP_ACCEL	/* for backward compatibility */
+
+#define XCHAL_HAVE_DFPU_SINGLE_ONLY	0	/* DFPU Coprocessor, single precision only */
+#define XCHAL_HAVE_DFPU_SINGLE_DOUBLE	0	/* DFPU Coprocessor, single and double precision */
+#define XCHAL_HAVE_VECTRA1		0	/* Vectra I  pkg */
+#define XCHAL_HAVE_VECTRALX		0	/* Vectra LX pkg */
+
+#define XCHAL_HAVE_FUSIONG		0    /* FusionG */
+#define XCHAL_HAVE_FUSIONG3		0    /* FusionG3 */
+#define XCHAL_HAVE_FUSIONG6		0    /* FusionG6 */
+#define XCHAL_HAVE_FUSIONG_SP_VFPU	0    /* sp_vfpu option on FusionG */
+#define XCHAL_HAVE_FUSIONG_DP_VFPU	0    /* dp_vfpu option on FusionG */
+#define XCHAL_FUSIONG_SIMD32		0    /* simd32 for FusionG */
+
+#define XCHAL_HAVE_FUSIONJ		0    /* FusionJ */
+#define XCHAL_HAVE_FUSIONJ6		0    /* FusionJ6 */
+#define XCHAL_HAVE_FUSIONJ_SP_VFPU	0    /* sp_vfpu option on FusionJ */
+#define XCHAL_HAVE_FUSIONJ_DP_VFPU	0    /* dp_vfpu option on FusionJ */
+#define XCHAL_FUSIONJ_SIMD32		0    /* simd32 for FusionJ */
+
+#define XCHAL_HAVE_PDX			0    /* PDX-LX */
+#define XCHAL_PDX_SIMD32		0    /* simd32 for PDX */
+#define XCHAL_HAVE_PDX4			0    /* PDX4-LX */
+#define XCHAL_HAVE_PDX8			0    /* PDX8-LX */
+#define XCHAL_HAVE_PDX16		0    /* PDX16-LX */
+#define XCHAL_HAVE_PDXNX 		0    /* PDX-NX */
+
+#define XCHAL_HAVE_CONNXD2		0	/* ConnX D2 pkg */
+#define XCHAL_HAVE_CONNXD2_DUALLSFLIX   0	/* ConnX D2 & Dual LoadStore Flix */
+#define XCHAL_HAVE_BALL			0
+#define XCHAL_HAVE_BALLAP		0
+#define XCHAL_HAVE_BBE16		0	/* ConnX BBE16 pkg */
+#define XCHAL_HAVE_BBE16_RSQRT		0	/* BBE16 & vector recip sqrt */
+#define XCHAL_HAVE_BBE16_VECDIV		0	/* BBE16 & vector divide */
+#define XCHAL_HAVE_BBE16_DESPREAD	0	/* BBE16 & despread */
+#define XCHAL_HAVE_CONNX_B10            0    /* ConnX B10 pkg*/
+#define XCHAL_HAVE_CONNX_B20            0    /* ConnX B20 pkg*/
+#define XCHAL_HAVE_CONNX_B_SP_VFPU      0    /* Single-precision Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_SPX_VFPU     0    /* Single-precision Extended Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_HPX_VFPU     0    /* Half-precision Extended Vector Floating-point option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_32B_MAC      0    /* 32-bit vector MAC (real and complex), FIR & FFT option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_VITERBI      0    /* Viterbi option on ConnX B10 & B20 */
+#define XCHAL_HAVE_CONNX_B_TURBO        0    /* Turbo option on ConnX B10 & B20 */
+#define XCHAL_HAVE_BBENEP		0	/* ConnX BBENEP pkgs */
+#define XCHAL_HAVE_BBENEP_SP_VFPU	0       /* sp_vfpu option on BBE-EP */
+#define XCHAL_HAVE_BSP3			0	/* ConnX BSP3 pkg */
+#define XCHAL_HAVE_BSP3_TRANSPOSE	0	/* BSP3 & transpose32x32 */
+#define XCHAL_HAVE_SSP16		0	/* ConnX SSP16 pkg */
+#define XCHAL_HAVE_SSP16_VITERBI	0	/* SSP16 & viterbi */
+#define XCHAL_HAVE_TURBO16		0	/* ConnX Turbo16 pkg */
+#define XCHAL_HAVE_BBP16		0	/* ConnX BBP16 pkg */
+#define XCHAL_HAVE_FLIX3		0	/* basic 3-way FLIX option */
+#define XCHAL_HAVE_GRIVPEP		0	/* General Release of IVPEP */
+#define XCHAL_HAVE_GRIVPEP_HISTOGRAM	0       /* Histogram option on GRIVPEP */
+
+#define XCHAL_HAVE_VISION	        0     /* Vision P5/P6 */
+#define XCHAL_VISION_SIMD16             0     /* simd16 for Vision P5/P6 */
+#define XCHAL_VISION_TYPE               0     /* Vision P5, P6, Q6 or Q7 */
+#define XCHAL_VISION_QUAD_MAC_TYPE      0     /* quad_mac option on Vision P6 */
+#define XCHAL_HAVE_VISION_HISTOGRAM     0     /* histogram option on Vision P5/P6 */
+#define XCHAL_HAVE_VISION_SP_VFPU       0     /* sp_vfpu option on Vision P5/P6/Q6/Q7 */
+#define XCHAL_HAVE_VISION_SP_VFPU_2XFMAC 0     /* sp_vfpu_2xfma option on Vision Q7 */
+#define XCHAL_HAVE_VISION_HP_VFPU       0     /* hp_vfpu option on Vision P6/Q6 */
+#define XCHAL_HAVE_VISION_HP_VFPU_2XFMAC 0     /* hp_vfpu_2xfma option on Vision Q7 */
+
+#define XCHAL_HAVE_VISIONC	        0     /* Vision C */
+
+#define XCHAL_HAVE_XNNE			0		/* XNNE */
+
+/*----------------------------------------------------------------------
+				MISC
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_NUM_LOADSTORE_UNITS	1	/* load/store units */
+#define XCHAL_NUM_WRITEBUFFER_ENTRIES	8	/* size of write buffer */
+#define XCHAL_INST_FETCH_WIDTH		4	/* instr-fetch width in bytes */
+#define XCHAL_DATA_WIDTH		4	/* data width in bytes */
+#define XCHAL_DATA_PIPE_DELAY		1	/* d-side pipeline delay
+						   (1 = 5-stage, 2 = 7-stage) */
+#define XCHAL_CLOCK_GATING_GLOBAL	1	/* global clock gating */
+#define XCHAL_CLOCK_GATING_FUNCUNIT	1	/* funct. unit clock gating */
+/*  In T1050, applies to selected core load and store instructions (see ISA): */
+#define XCHAL_UNALIGNED_LOAD_EXCEPTION	1	/* unaligned loads cause exc. */
+#define XCHAL_UNALIGNED_STORE_EXCEPTION	1	/* unaligned stores cause exc.*/
+#define XCHAL_UNALIGNED_LOAD_HW		0	/* unaligned loads work in hw */
+#define XCHAL_UNALIGNED_STORE_HW	0	/* unaligned stores work in hw*/
+
+#define XCHAL_UNIFIED_LOADSTORE         0
+
+#define XCHAL_SW_VERSION		1402000	/* sw version of this header */
+#define XCHAL_SW_VERSION_MAJOR		14000	/* major ver# of sw          */
+#define XCHAL_SW_VERSION_MINOR		2	/* minor ver# of sw          */
+#define XCHAL_SW_VERSION_MICRO		0	/* micro ver# of sw          */
+#define XCHAL_SW_MINOR_VERSION		1402000	/* with zeroed micro */
+#define XCHAL_SW_MICRO_VERSION		1402000
+
+#define XCHAL_CORE_ID			"sample_controller32"	/* alphanum core name
+						   (CoreID) set in the Xtensa
+						   Processor Generator */
+
+#define XCHAL_BUILD_UNIQUE_ID		0x00086263	/* 22-bit sw build ID */
+
+/*
+ *  These definitions describe the hardware targeted by this software.
+ */
+#define XCHAL_HW_CONFIGID0		0xC0009286	/* ConfigID hi 32 bits*/
+#define XCHAL_HW_CONFIGID1		0x28886263	/* ConfigID lo 32 bits*/
+#define XCHAL_HW_VERSION_NAME		"LX7.1.2"	/* full version name */
+#define XCHAL_HW_VERSION_MAJOR		2810	/* major ver# of targeted hw */
+#define XCHAL_HW_VERSION_MINOR		2	/* minor ver# of targeted hw */
+#define XCHAL_HW_VERSION_MICRO		0	/* subdot ver# of targeted hw */
+#define XCHAL_HW_VERSION		281020	/* major*100+(major<2810 ? minor : minor*10+micro) */
+#define XCHAL_HW_REL_LX7		1
+#define XCHAL_HW_REL_LX7_1		1
+#define XCHAL_HW_REL_LX7_1_2		1
+#define XCHAL_HW_CONFIGID_RELIABLE	1
+/*  If software targets a *range* of hardware versions, these are the bounds: */
+#define XCHAL_HW_MIN_VERSION_MAJOR	2810	/* major v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MINOR	2	/* minor v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MICRO	0	/* micro v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION		281020	/* earliest targeted hw */
+#define XCHAL_HW_MAX_VERSION_MAJOR	2810	/* major v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MINOR	2	/* minor v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MICRO	0	/* micro v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION		281020	/* latest targeted hw */
+
+/*  Config is enabled for functional safety: */
+#define XCHAL_HAVE_FUNC_SAFETY		0
+
+#define XCHAL_HAVE_APB			0 
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_ICACHE_LINESIZE		4	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		4	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		2	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		2	/* log2(D line size in bytes) */
+
+#define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
+#define XCHAL_ICACHE_SIZE_LOG2		0
+#define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */
+#define XCHAL_DCACHE_SIZE_LOG2		0
+
+#define XCHAL_DCACHE_IS_WRITEBACK	0	/* writeback feature */
+#define XCHAL_DCACHE_IS_COHERENT	0	/* MP coherence feature */
+
+#define XCHAL_HAVE_PREFETCH		0	/* PREFCTL register */
+#define XCHAL_HAVE_PREFETCH_L1		0	/* prefetch to L1 cache */
+#define XCHAL_PREFETCH_CASTOUT_LINES	0	/* dcache pref. castout bufsz */
+#define XCHAL_PREFETCH_ENTRIES		0	/* cache prefetch entries */
+#define XCHAL_PREFETCH_BLOCK_ENTRIES	0	/* prefetch block streams */
+#define XCHAL_HAVE_CACHE_BLOCKOPS	0	/* block prefetch for caches */
+#define XCHAL_HAVE_CME_DOWNGRADES	0
+#define XCHAL_HAVE_ICACHE_TEST		0	/* Icache test instructions */
+#define XCHAL_HAVE_DCACHE_TEST		0	/* Dcache test instructions */
+#define XCHAL_HAVE_ICACHE_DYN_WAYS	0	/* Icache dynamic way support */
+#define XCHAL_HAVE_DCACHE_DYN_WAYS	0	/* Dcache dynamic way support */
+#define XCHAL_HAVE_ICACHE_DYN_ENABLE	0	/* Icache enabled via MEMCTL */
+#define XCHAL_HAVE_DCACHE_DYN_ENABLE	0	/* Dcache enabled via MEMCTL */
+
+#define XCHAL_L1SCACHE_SIZE		         0
+#define XCHAL_L1SCACHE_SIZE_LOG2		 0
+#define XCHAL_L1SCACHE_WAYS              1
+#define XCHAL_L1SCACHE_WAYS_LOG2         0
+#define XCHAL_L1SCACHE_ACCESS_SIZE       0
+#define XCHAL_L1SCACHE_BANKS             1
+
+#define XCHAL_HAVE_L2			0	/* NX L2 cache controller */
+
+/*  This one is a form of caching, though not architecturally visible:  */
+#define XCHAL_HAVE_BRANCH_PREDICTION	0	/* branch [target] prediction */
+
+
+
+
+/****************************************************************************
+    Parameters Useful for PRIVILEGED (Supervisory or Non-Virtualized) Code
+ ****************************************************************************/
+
+
+#ifndef XTENSA_HAL_NON_PRIVILEGED_ONLY
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_PIF			1	/* any outbound bus present */
+
+#define XCHAL_HAVE_AXI			1	/* AXI bus */
+#define XCHAL_HAVE_AXI_ECC		1	/* ECC on AXI bus */
+#define XCHAL_HAVE_ACELITE		0	/* ACELite bus */
+
+#define XCHAL_HAVE_PIF_WR_RESP			1	/* pif write response */
+#define XCHAL_HAVE_PIF_REQ_ATTR			0	/* pif attribute */
+
+/*  If present, cache size in bytes == (ways * 2^(linewidth + setwidth)).  */
+
+/*  Number of cache sets in log2(lines per way):  */
+#define XCHAL_ICACHE_SETWIDTH		0
+#define XCHAL_DCACHE_SETWIDTH		0
+
+/*  Cache set associativity (number of ways):  */
+#define XCHAL_ICACHE_WAYS		1
+#define XCHAL_ICACHE_WAYS_LOG2		0
+#define XCHAL_DCACHE_WAYS		1
+#define XCHAL_DCACHE_WAYS_LOG2		0
+
+/*  Cache features:  */
+#define XCHAL_ICACHE_LINE_LOCKABLE	0
+#define XCHAL_DCACHE_LINE_LOCKABLE	0
+#define XCHAL_ICACHE_ECC_PARITY		0
+#define XCHAL_DCACHE_ECC_PARITY		0
+#define XCHAL_ICACHE_ECC_WIDTH		1
+#define XCHAL_DCACHE_ECC_WIDTH		1
+
+/*  Cache access size in bytes (affects operation of SICW instruction):  */
+#define XCHAL_ICACHE_ACCESS_SIZE	1
+#define XCHAL_DCACHE_ACCESS_SIZE	1
+
+#define XCHAL_DCACHE_BANKS		0	/* number of banks */
+
+/* The number of Cache lines associated with a single cache tag */
+#define XCHAL_DCACHE_LINES_PER_TAG_LOG2	0
+
+/*  Number of encoded cache attr bits (see <xtensa/hal.h> for decoded bits):  */
+
+
+/*----------------------------------------------------------------------
+			INTERNAL I/D RAM/ROMs and XLMI
+  ----------------------------------------------------------------------*/
+#define XCHAL_NUM_INSTROM		0	/* number of core instr. ROMs */
+#define XCHAL_NUM_INSTRAM		1	/* number of core instr. RAMs */
+#define XCHAL_NUM_DATAROM		0	/* number of core data ROMs */
+#define XCHAL_NUM_DATARAM		2	/* number of core data RAMs */
+#define XCHAL_NUM_URAM			0	/* number of core unified RAMs*/
+#define XCHAL_NUM_XLMI			0	/* number of core XLMI ports */
+#define	XCHAL_HAVE_IRAMCFG		0	/* IRAMxCFG register present */
+#define	XCHAL_HAVE_DRAMCFG		0	/* DRAMxCFG register present */
+
+/*  Instruction RAM 0:  */
+#define XCHAL_INSTRAM0_VADDR		0x40000000	/* virtual address */
+#define XCHAL_INSTRAM0_PADDR		0x40000000	/* physical address */
+#define XCHAL_INSTRAM0_SIZE		131072	/* size in bytes */
+#define XCHAL_INSTRAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_HAVE_INSTRAM0		1
+#define XCHAL_INSTRAM0_HAVE_IDMA	0	/* idma supported by this local memory */
+
+/*  Data RAM 0:  */
+#define XCHAL_DATARAM0_VADDR		0x3FFE0000	/* virtual address */
+#define XCHAL_DATARAM0_PADDR		0x3FFE0000	/* physical address */
+#define XCHAL_DATARAM0_SIZE		131072	/* size in bytes */
+#define XCHAL_DATARAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_DATARAM0_BANKS		1	/* number of banks */
+#define XCHAL_HAVE_DATARAM0		1
+#define XCHAL_DATARAM0_HAVE_IDMA	0	/* idma supported by this local memory */
+
+/*  Data RAM 1:  */
+#define XCHAL_DATARAM1_VADDR		0x3FFC0000	/* virtual address */
+#define XCHAL_DATARAM1_PADDR		0x3FFC0000	/* physical address */
+#define XCHAL_DATARAM1_SIZE		131072	/* size in bytes */
+#define XCHAL_DATARAM1_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_DATARAM1_BANKS		1	/* number of banks */
+#define XCHAL_HAVE_DATARAM1		1
+#define XCHAL_DATARAM1_HAVE_IDMA	0	/* idma supported by this local memory */
+
+
+#define XCHAL_HAVE_IDMA			0
+
+
+#define XCHAL_HAVE_IMEM_LOADSTORE	1	/* can load/store to IROM/IRAM*/
+
+/*----------------------------------------------------------------------
+			INTERRUPTS and TIMERS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_INTERRUPTS		1	/* interrupt option */
+#define XCHAL_HAVE_NMI			1	/* non-maskable interrupt */
+#define XCHAL_HAVE_CCOUNT		1	/* CCOUNT reg. (timer option) */
+#define XCHAL_NUM_TIMERS		3	/* number of CCOMPAREn regs */
+#define XCHAL_NUM_INTERRUPTS		23	/* number of interrupts */
+#define XCHAL_NUM_INTERRUPTS_LOG2	5	/* ceil(log2(NUM_INTERRUPTS)) */
+#define XCHAL_NUM_EXTINTERRUPTS		17	/* num of external interrupts */
+#define XCHAL_NUM_INTLEVELS		6	/* number of interrupt levels
+						   (not including level zero) */
+
+
+#define XCHAL_HAVE_HIGHPRI_INTERRUPTS	1   /* med/high-pri. interrupts */
+#define XCHAL_EXCM_LEVEL		3	/* level masked by PS.EXCM */
+	/* (always 1 in XEA1; levels 2 .. EXCM_LEVEL are "medium priority") */
+
+/*  Masks of interrupts at each interrupt level:  */
+#define XCHAL_INTLEVEL1_MASK		0x005F80FF
+#define XCHAL_INTLEVEL2_MASK		0x00000100
+#define XCHAL_INTLEVEL3_MASK		0x00200E00
+#define XCHAL_INTLEVEL4_MASK		0x00001000
+#define XCHAL_INTLEVEL5_MASK		0x00002000
+#define XCHAL_INTLEVEL6_MASK		0x00000000
+#define XCHAL_INTLEVEL7_MASK		0x00004000
+
+/*  Masks of interrupts at each range 1..n of interrupt levels:  */
+#define XCHAL_INTLEVEL1_ANDBELOW_MASK	0x005F80FF
+#define XCHAL_INTLEVEL2_ANDBELOW_MASK	0x005F81FF
+#define XCHAL_INTLEVEL3_ANDBELOW_MASK	0x007F8FFF
+#define XCHAL_INTLEVEL4_ANDBELOW_MASK	0x007F9FFF
+#define XCHAL_INTLEVEL5_ANDBELOW_MASK	0x007FBFFF
+#define XCHAL_INTLEVEL6_ANDBELOW_MASK	0x007FBFFF
+#define XCHAL_INTLEVEL7_ANDBELOW_MASK	0x007FFFFF
+
+/*  Level of each interrupt:  */
+#define XCHAL_INT0_LEVEL		1
+#define XCHAL_INT1_LEVEL		1
+#define XCHAL_INT2_LEVEL		1
+#define XCHAL_INT3_LEVEL		1
+#define XCHAL_INT4_LEVEL		1
+#define XCHAL_INT5_LEVEL		1
+#define XCHAL_INT6_LEVEL		1
+#define XCHAL_INT7_LEVEL		1
+#define XCHAL_INT8_LEVEL		2
+#define XCHAL_INT9_LEVEL		3
+#define XCHAL_INT10_LEVEL		3
+#define XCHAL_INT11_LEVEL		3
+#define XCHAL_INT12_LEVEL		4
+#define XCHAL_INT13_LEVEL		5
+#define XCHAL_INT14_LEVEL		7
+#define XCHAL_INT15_LEVEL		1
+#define XCHAL_INT16_LEVEL		1
+#define XCHAL_INT17_LEVEL		1
+#define XCHAL_INT18_LEVEL		1
+#define XCHAL_INT19_LEVEL		1
+#define XCHAL_INT20_LEVEL		1
+#define XCHAL_INT21_LEVEL		3
+#define XCHAL_INT22_LEVEL		1
+#define XCHAL_DEBUGLEVEL		6	/* debug interrupt level */
+#define XCHAL_HAVE_DEBUG_EXTERN_INT	1	/* OCD external db interrupt */
+#define XCHAL_NMILEVEL			7	/* NMI "level" (for use with
+						   EXCSAVE/EPS/EPC_n, RFI n) */
+
+/*  Type of each interrupt:  */
+#define XCHAL_INT0_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT1_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT2_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT3_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT4_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT5_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT6_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT7_TYPE 	XTHAL_INTTYPE_SOFTWARE
+#define XCHAL_INT8_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT9_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT10_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT11_TYPE 	XTHAL_INTTYPE_SOFTWARE
+#define XCHAL_INT12_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT13_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT14_TYPE 	XTHAL_INTTYPE_NMI
+#define XCHAL_INT15_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT16_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT17_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT18_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT19_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT20_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT21_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT22_TYPE 	XTHAL_INTTYPE_WRITE_ERROR
+
+/*  Masks of interrupts for each type of interrupt:  */
+#define XCHAL_INTTYPE_MASK_UNCONFIGURED	0xFF800000
+#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x0000133F
+#define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x003F8000
+#define XCHAL_INTTYPE_MASK_NMI		0x00004000
+#define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000880
+#define XCHAL_INTTYPE_MASK_TIMER	0x00002440
+#define XCHAL_INTTYPE_MASK_WRITE_ERROR	0x00400000
+#define XCHAL_INTTYPE_MASK_DBG_REQUEST	0x00000000
+#define XCHAL_INTTYPE_MASK_BREAKIN	0x00000000
+#define XCHAL_INTTYPE_MASK_TRAX		0x00000000
+#define XCHAL_INTTYPE_MASK_PROFILING	0x00000000
+#define XCHAL_INTTYPE_MASK_IDMA_DONE	0x00000000
+#define XCHAL_INTTYPE_MASK_IDMA_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_GS_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_L2_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_L2_STATUS	0x00000000
+#define XCHAL_INTTYPE_MASK_COR_ECC_ERR	0x00000000
+
+/*  Interrupt numbers assigned to specific interrupt sources:  */
+#define XCHAL_TIMER0_INTERRUPT		6	/* CCOMPARE0 */
+#define XCHAL_TIMER1_INTERRUPT		10	/* CCOMPARE1 */
+#define XCHAL_TIMER2_INTERRUPT		13	/* CCOMPARE2 */
+#define XCHAL_TIMER3_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_NMI_INTERRUPT		14	/* non-maskable interrupt */
+#define XCHAL_WRITE_ERROR_INTERRUPT	22
+
+/*  Interrupt numbers for levels at which only one interrupt is configured:  */
+#define XCHAL_INTLEVEL2_NUM		8
+#define XCHAL_INTLEVEL4_NUM		12
+#define XCHAL_INTLEVEL5_NUM		13
+#define XCHAL_INTLEVEL7_NUM		14
+/*  (There are many interrupts each at level(s) 1, 3.)  */
+
+
+/*
+ *  External interrupt mapping.
+ *  These macros describe how Xtensa processor interrupt numbers
+ *  (as numbered internally, eg. in INTERRUPT and INTENABLE registers)
+ *  map to external BInterrupt<n> pins, for those interrupts
+ *  configured as external (level-triggered, edge-triggered, or NMI).
+ *  See the Xtensa processor databook for more details.
+ */
+
+/*  Core interrupt numbers mapped to each EXTERNAL BInterrupt pin number:  */
+#define XCHAL_EXTINT0_NUM		0	/* (intlevel 1) */
+#define XCHAL_EXTINT1_NUM		1	/* (intlevel 1) */
+#define XCHAL_EXTINT2_NUM		2	/* (intlevel 1) */
+#define XCHAL_EXTINT3_NUM		3	/* (intlevel 1) */
+#define XCHAL_EXTINT4_NUM		4	/* (intlevel 1) */
+#define XCHAL_EXTINT5_NUM		5	/* (intlevel 1) */
+#define XCHAL_EXTINT6_NUM		8	/* (intlevel 2) */
+#define XCHAL_EXTINT7_NUM		9	/* (intlevel 3) */
+#define XCHAL_EXTINT8_NUM		12	/* (intlevel 4) */
+#define XCHAL_EXTINT9_NUM		14	/* (intlevel 7) */
+#define XCHAL_EXTINT10_NUM		15	/* (intlevel 1) */
+#define XCHAL_EXTINT11_NUM		16	/* (intlevel 1) */
+#define XCHAL_EXTINT12_NUM		17	/* (intlevel 1) */
+#define XCHAL_EXTINT13_NUM		18	/* (intlevel 1) */
+#define XCHAL_EXTINT14_NUM		19	/* (intlevel 1) */
+#define XCHAL_EXTINT15_NUM		20	/* (intlevel 1) */
+#define XCHAL_EXTINT16_NUM		21	/* (intlevel 3) */
+/*  EXTERNAL BInterrupt pin numbers mapped to each core interrupt number:  */
+#define XCHAL_INT0_EXTNUM		0	/* (intlevel 1) */
+#define XCHAL_INT1_EXTNUM		1	/* (intlevel 1) */
+#define XCHAL_INT2_EXTNUM		2	/* (intlevel 1) */
+#define XCHAL_INT3_EXTNUM		3	/* (intlevel 1) */
+#define XCHAL_INT4_EXTNUM		4	/* (intlevel 1) */
+#define XCHAL_INT5_EXTNUM		5	/* (intlevel 1) */
+#define XCHAL_INT8_EXTNUM		6	/* (intlevel 2) */
+#define XCHAL_INT9_EXTNUM		7	/* (intlevel 3) */
+#define XCHAL_INT12_EXTNUM		8	/* (intlevel 4) */
+#define XCHAL_INT14_EXTNUM		9	/* (intlevel 7) */
+#define XCHAL_INT15_EXTNUM		10	/* (intlevel 1) */
+#define XCHAL_INT16_EXTNUM		11	/* (intlevel 1) */
+#define XCHAL_INT17_EXTNUM		12	/* (intlevel 1) */
+#define XCHAL_INT18_EXTNUM		13	/* (intlevel 1) */
+#define XCHAL_INT19_EXTNUM		14	/* (intlevel 1) */
+#define XCHAL_INT20_EXTNUM		15	/* (intlevel 1) */
+#define XCHAL_INT21_EXTNUM		16	/* (intlevel 3) */
+
+#define	XCHAL_HAVE_ISB			0	/* No ISB */
+#define	XCHAL_ISB_VADDR			0	/* N/A    */
+#define	XCHAL_HAVE_ITB			0	/* No ITB */
+#define	XCHAL_ITB_VADDR			0	/* N/A    */
+
+#define	XCHAL_HAVE_KSL			0	/* Kernel Stack Limit */
+#define	XCHAL_HAVE_ISL			0	/* Interrupt Stack Limit */
+#define	XCHAL_HAVE_PSL			0	/* Pageable Stack Limit */
+
+
+/*----------------------------------------------------------------------
+			EXCEPTIONS and VECTORS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_XEA_VERSION		2	/* Xtensa Exception Architecture
+						   number: 1 == XEA1 (until T1050)
+							   2 == XEA2 (T1040 onwards)
+							   3 == XEA3 (LX8/NX/SX onwards)
+							   0 == XEAX (extern) or TX */
+#define XCHAL_HAVE_XEA1			0	/* Exception Architecture 1 */
+#define XCHAL_HAVE_XEA2			1	/* Exception Architecture 2 */
+#define XCHAL_HAVE_XEA3			0	/* Exception Architecture 3 */
+#define XCHAL_HAVE_XEAX			0	/* External Exception Arch. */
+#define XCHAL_HAVE_EXCEPTIONS		1	/* exception option */
+#define XCHAL_HAVE_IMPRECISE_EXCEPTIONS	0	/* imprecise exception option */
+#define	XCHAL_EXCCAUSE_NUM		64	/* Number of exceptions */
+#define XCHAL_HAVE_HALT			0	/* halt architecture option */
+#define XCHAL_HAVE_BOOTLOADER		0	/* boot loader (for TX) */
+#define XCHAL_HAVE_MEM_ECC_PARITY	0	/* local memory ECC/parity */
+#define XCHAL_HAVE_VECTOR_SELECT	1	/* relocatable vectors */
+#define XCHAL_HAVE_VECBASE		1	/* relocatable vectors */
+#define XCHAL_VECBASE_RESET_VADDR	0x40000000  /* VECBASE reset value */
+#define XCHAL_VECBASE_RESET_PADDR	0x40000000
+#define XCHAL_RESET_VECBASE_OVERLAP	0	/* UNUSED */
+
+#define XCHAL_RESET_VECTOR0_VADDR	0x50000000
+#define XCHAL_RESET_VECTOR0_PADDR	0x50000000
+#define XCHAL_RESET_VECTOR1_VADDR	0x40000400
+#define XCHAL_RESET_VECTOR1_PADDR	0x40000400
+#define XCHAL_RESET_VECTOR_VADDR	XCHAL_RESET_VECTOR0_VADDR
+#define XCHAL_RESET_VECTOR_PADDR	XCHAL_RESET_VECTOR0_PADDR
+#define XCHAL_USER_VECOFS		0x00000340
+#define XCHAL_USER_VECTOR_VADDR		0x40000340
+#define XCHAL_USER_VECTOR_PADDR		0x40000340
+#define XCHAL_KERNEL_VECOFS		0x00000300
+#define XCHAL_KERNEL_VECTOR_VADDR	0x40000300
+#define XCHAL_KERNEL_VECTOR_PADDR	0x40000300
+#define XCHAL_DOUBLEEXC_VECOFS		0x000003C0
+#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x400003C0
+#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x400003C0
+#define XCHAL_WINDOW_OF4_VECOFS		0x00000000
+#define XCHAL_WINDOW_UF4_VECOFS		0x00000040
+#define XCHAL_WINDOW_OF8_VECOFS		0x00000080
+#define XCHAL_WINDOW_UF8_VECOFS		0x000000C0
+#define XCHAL_WINDOW_OF12_VECOFS	0x00000100
+#define XCHAL_WINDOW_UF12_VECOFS	0x00000140
+#define XCHAL_WINDOW_VECTORS_VADDR	0x40000000
+#define XCHAL_WINDOW_VECTORS_PADDR	0x40000000
+#define XCHAL_INTLEVEL2_VECOFS		0x00000180
+#define XCHAL_INTLEVEL2_VECTOR_VADDR	0x40000180
+#define XCHAL_INTLEVEL2_VECTOR_PADDR	0x40000180
+#define XCHAL_INTLEVEL3_VECOFS		0x000001C0
+#define XCHAL_INTLEVEL3_VECTOR_VADDR	0x400001C0
+#define XCHAL_INTLEVEL3_VECTOR_PADDR	0x400001C0
+#define XCHAL_INTLEVEL4_VECOFS		0x00000200
+#define XCHAL_INTLEVEL4_VECTOR_VADDR	0x40000200
+#define XCHAL_INTLEVEL4_VECTOR_PADDR	0x40000200
+#define XCHAL_INTLEVEL5_VECOFS		0x00000240
+#define XCHAL_INTLEVEL5_VECTOR_VADDR	0x40000240
+#define XCHAL_INTLEVEL5_VECTOR_PADDR	0x40000240
+#define XCHAL_INTLEVEL6_VECOFS		0x00000280
+#define XCHAL_INTLEVEL6_VECTOR_VADDR	0x40000280
+#define XCHAL_INTLEVEL6_VECTOR_PADDR	0x40000280
+#define XCHAL_DEBUG_VECOFS		XCHAL_INTLEVEL6_VECOFS
+#define XCHAL_DEBUG_VECTOR_VADDR	XCHAL_INTLEVEL6_VECTOR_VADDR
+#define XCHAL_DEBUG_VECTOR_PADDR	XCHAL_INTLEVEL6_VECTOR_PADDR
+#define XCHAL_NMI_VECOFS		0x000002C0
+#define XCHAL_NMI_VECTOR_VADDR		0x400002C0
+#define XCHAL_NMI_VECTOR_PADDR		0x400002C0
+#define XCHAL_INTLEVEL7_VECOFS		XCHAL_NMI_VECOFS
+#define XCHAL_INTLEVEL7_VECTOR_VADDR	XCHAL_NMI_VECTOR_VADDR
+#define XCHAL_INTLEVEL7_VECTOR_PADDR	XCHAL_NMI_VECTOR_PADDR
+
+
+/*----------------------------------------------------------------------
+				DEBUG MODULE
+  ----------------------------------------------------------------------*/
+
+/*  Misc  */
+#define XCHAL_HAVE_DEBUG_ERI		0	/* ERI to debug module */
+#define XCHAL_HAVE_DEBUG_APB		0	/* APB to debug module */
+#define XCHAL_HAVE_DEBUG_JTAG		1	/* JTAG to debug module */
+
+/*  On-Chip Debug (OCD)  */
+#define XCHAL_HAVE_OCD			1	/* OnChipDebug option */
+#define XCHAL_NUM_IBREAK		2	/* number of IBREAKn regs */
+#define XCHAL_NUM_DBREAK		2	/* number of DBREAKn regs */
+#define XCHAL_HAVE_OCD_DIR_ARRAY	0	/* faster OCD option (to LX4) */
+#define XCHAL_HAVE_OCD_LS32DDR		1	/* L32DDR/S32DDR (faster OCD) */
+
+/*  TRAX (in core)  */
+#define XCHAL_HAVE_TRAX			0	/* TRAX in debug module */
+#define XCHAL_TRAX_MEM_SIZE		0	/* TRAX memory size in bytes */
+#define XCHAL_TRAX_MEM_SHAREABLE	0	/* start/end regs; ready sig. */
+#define XCHAL_TRAX_ATB_WIDTH		0	/* ATB width (bits), 0=no ATB */
+#define XCHAL_TRAX_TIME_WIDTH		0	/* timestamp bitwidth, 0=none */
+
+/*  Perf counters  */
+#define XCHAL_NUM_PERF_COUNTERS		0	/* performance counters */
+
+
+/*----------------------------------------------------------------------
+				MMU
+  ----------------------------------------------------------------------*/
+
+/*  See core-matmap.h header file for more details.  */
+
+#define XCHAL_HAVE_TLBS			0	/* inverse of HAVE_CACHEATTR */
+#define XCHAL_HAVE_SPANNING_WAY		0	/* one way maps I+D 4GB vaddr */
+#define XCHAL_HAVE_IDENTITY_MAP		1	/* vaddr == paddr always */
+#define XCHAL_HAVE_CACHEATTR		0	/* CACHEATTR register present */
+#define XCHAL_HAVE_MIMIC_CACHEATTR	0	/* region protection */
+#define XCHAL_HAVE_XLT_CACHEATTR	0	/* region prot. w/translation */
+#define XCHAL_HAVE_PTP_MMU		0	/* full MMU (with page table
+						   [autorefill] and protection)
+						   usable for an MMU-based OS */
+
+/*  If none of the above last 5 are set, it's a custom TLB configuration.  */
+
+#define XCHAL_MMU_ASID_BITS		0	/* number of bits in ASIDs */
+#define XCHAL_MMU_RINGS			1	/* number of rings (1..4) */
+#define XCHAL_MMU_RING_BITS		0	/* num of bits in RING field */
+
+/*----------------------------------------------------------------------
+				MPU
+  ----------------------------------------------------------------------*/
+#define XCHAL_HAVE_MPU			1 
+#define XCHAL_MPU_ENTRIES		32
+
+#define XCHAL_MPU_ALIGN_REQ		1	/* MPU requires alignment of entries to background map */
+#define XCHAL_MPU_BACKGROUND_ENTRIES	2	/* number of entries in bg map*/
+#define XCHAL_MPU_BG_CACHEADRDIS	0xFF	/* default CACHEADRDIS for bg */
+ 
+#define XCHAL_MPU_ALIGN_BITS		12
+#define XCHAL_MPU_ALIGN			4096
+
+#endif /* !XTENSA_HAL_NON_PRIVILEGED_ONLY */
+
+
+#endif /* XTENSA_CORE_CONFIGURATION_H_ */
+

--- a/zephyr/soc/sample_controller32/xtensa/config/core-matmap.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/core-matmap.h
@@ -1,0 +1,106 @@
+/* 
+ * xtensa/config/core-matmap.h -- Memory access and translation mapping
+ *	parameters (CHAL) of the Xtensa processor core configuration.
+ *
+ *  If you are using Xtensa Tools, see <xtensa/config/core.h> (which includes
+ *  this file) for more details.
+ *
+ *  In the Xtensa processor products released to date, all parameters
+ *  defined in this file are derivable (at least in theory) from
+ *  information contained in the core-isa.h header file.
+ *  In particular, the following core configuration parameters are relevant:
+ *	XCHAL_HAVE_CACHEATTR
+ *	XCHAL_HAVE_MIMIC_CACHEATTR
+ *	XCHAL_HAVE_XLT_CACHEATTR
+ *	XCHAL_HAVE_PTP_MMU
+ *	XCHAL_ITLB_ARF_ENTRIES_LOG2
+ *	XCHAL_DTLB_ARF_ENTRIES_LOG2
+ *	XCHAL_DCACHE_IS_WRITEBACK
+ *	XCHAL_ICACHE_SIZE		(presence of I-cache)
+ *	XCHAL_DCACHE_SIZE		(presence of D-cache)
+ *	XCHAL_HW_VERSION_MAJOR
+ *	XCHAL_HW_VERSION_MINOR
+ */
+
+/* Copyright (c) 1999-2019 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+
+#ifndef XTENSA_CONFIG_CORE_MATMAP_H
+#define XTENSA_CONFIG_CORE_MATMAP_H
+
+
+/*----------------------------------------------------------------------
+			CACHE (MEMORY ACCESS) ATTRIBUTES
+  ----------------------------------------------------------------------*/
+/*----------------------------------------------------------------------
+				MPU
+  ----------------------------------------------------------------------*/
+
+/* Mappings for legacy constants where appropriate */
+
+#define XCHAL_CA_WRITEBACK (XTHAL_MEM_WRITEBACK | XTHAL_AR_RWXrwx)
+
+#define XCHAL_CA_WRITEBACK_NOALLOC (XTHAL_MEM_WRITEBACK_NOALLOC| XTHAL_AR_RWXrwx )
+
+#define XCHAL_CA_WRITETHRU (XTHAL_MEM_WRITETHRU | XTHAL_AR_RWXrwx)
+
+#define XCHAL_CA_ILLEGAL   (XTHAL_AR_NONE   | XTHAL_MEM_DEVICE)
+#define XCHAL_CA_BYPASS    (XTHAL_AR_RWXrwx | XTHAL_MEM_DEVICE)
+#define XCHAL_CA_BYPASSBUF    (XTHAL_AR_RWXrwx | XTHAL_MEM_DEVICE |\
+        XTHAL_MEM_BUFFERABLE)
+#define XCHAL_CA_BYPASS_RX (XTHAL_AR_RX     | XTHAL_MEM_DEVICE)
+#define XCHAL_CA_BYPASS_RW (XTHAL_AR_RW     | XTHAL_MEM_DEVICE)
+#define XCHAL_CA_BYPASS_R  (XTHAL_AR_R      | XTHAL_MEM_DEVICE)
+#define XCHAL_HAVE_CA_WRITEBACK_NOALLOC 1
+
+#define XCHAL_CA_R  (XTHAL_AR_R)
+#define XCHAL_CA_RX (XTHAL_AR_RX) 
+#define XCHAL_CA_RW (XTHAL_AR_RW) 
+#define XCHAL_CA_RWX (XTHAL_AR_RWX)
+
+
+/* 
+ * Contents of MPU background map.
+ * NOTE:  caller must define the XCHAL_MPU_BGMAP() macro (not defined here
+ * but specified below) before expanding the XCHAL_MPU_BACKGROUND_MAP(s) macro.
+ *
+ * XCHAL_MPU_BGMAP(s, vaddr_start, vaddr_last, rights, memtype, x...)
+ *
+ *	s = passed from XCHAL_MPU_BACKGROUND_MAP(s), eg. to select how to expand
+ *	vaddr_start = first byte of region (always 0 for first entry)
+ *	vaddr_end = last byte of region (always 0xFFFFFFFF for last entry)
+ *	rights = access rights
+ *	memtype = memory type
+ *	x = reserved for future use (0 until then)
+ */
+/* parasoft-begin-suppress MISRA2012-RULE-20_7 "Macro use model requires s to not be in ()" */
+#define XCHAL_MPU_BACKGROUND_MAP(s) \
+	XCHAL_MPU_BGMAP(s, 0x00000000, 0x7fffffff,  7,   6, 0) \
+	XCHAL_MPU_BGMAP(s, 0x80000000, 0xffffffff,  7,   6, 0) \
+/* parasoft-end-suppress MISRA2012-RULE-20_7 "Macro use model requires s to not be in ()" */
+
+	/* end */
+
+
+
+#endif /*XTENSA_CONFIG_CORE_MATMAP_H*/
+

--- a/zephyr/soc/sample_controller32/xtensa/config/core.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/core.h
@@ -1,0 +1,1359 @@
+/* 
+ * xtensa/config/core.h -- HAL definitions dependent on CORE configuration
+ *
+ *  This header file is sometimes referred to as the "compile-time HAL" or CHAL.
+ *  It pulls definitions tailored for a specific Xtensa processor configuration.
+ *
+ *  Sources for binaries meant to be configuration-independent generally avoid
+ *  including this file (they may use the configuration-specific HAL library).
+ *  It is normal for the HAL library source itself to include this file.
+ */
+
+/*
+ * Copyright (c) 2005-2016 Cadence Design Systems, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+#ifndef XTENSA_CONFIG_CORE_H
+#define XTENSA_CONFIG_CORE_H
+
+/*  CONFIGURATION INDEPENDENT DEFINITIONS:  */
+#ifdef __XTENSA__
+#include <xtensa/hal.h>
+#include <xtensa/xtensa-versions.h>
+#include <xtensa/xtensa-types.h>
+#else
+#include "../hal.h"
+#include "../xtensa-versions.h"
+#include "../xtensa-types.h"
+#endif
+
+/*  CONFIGURATION SPECIFIC DEFINITIONS:  */
+#ifdef __XTENSA__
+#include <xtensa/config/core-isa.h>
+#include <xtensa/config/core-matmap.h>
+#include <xtensa/config/tie.h>
+#else
+#include "core-isa.h"
+#include "core-matmap.h"
+#include "tie.h"
+#endif
+
+#if defined (_ASMLANGUAGE) || defined (__ASSEMBLER__)
+#ifdef __XTENSA__
+#include <xtensa/coreasm.h>
+#include <xtensa/config/tie-asm.h>
+#else
+#include "coreasm.h"
+#include "tie-asm.h"
+#endif
+#endif /*_ASMLANGUAGE or __ASSEMBLER__*/
+
+
+/*----------------------------------------------------------------------
+				GENERAL
+  ----------------------------------------------------------------------*/
+
+/*
+ *  Separators for macros that expand into arrays.
+ *  These can be predefined by files that #include this one,
+ *  when different separators are required.
+ */
+/*  Element separator for macros that expand into 1-dimensional arrays:  */
+#ifndef XCHAL_SEP
+#define XCHAL_SEP			,
+#endif
+/*  Array separator for macros that expand into 2-dimensional arrays:  */
+#ifndef XCHAL_SEP2
+#define XCHAL_SEP2			},{
+#endif
+
+/*  Variadic macros for indexing and selecting.  */
+/* parasoft-begin-suppress MISRA2012-RULE-20_7 "enclosing 'x' in parenthesis not appropriate when argument is __VA_ARGS__" */
+
+/*  For MSVC:  */
+#define XCHAL_EXPAND(x)       x
+
+/*  XCHAL_SELECT(n, ...) expands argument 'n' (0..19) of '...'.  */
+#define XCHAL__0(x, ...) x
+#define XCHAL__1(a, x, ...) x
+#define XCHAL__2(a,b, x, ...) x
+#define XCHAL__3(a,b,c, x, ...) x
+#define XCHAL__4(a,b,c,d, x, ...) x
+#define XCHAL__5(a,b,c,d,e, x, ...) x
+#define XCHAL__6(a,b,c,d,e,f, x, ...) x
+#define XCHAL__7(a,b,c,d,e,f,g, x, ...) x
+#define XCHAL__8(a,b,c,d,e,f,g,h, x, ...) x
+#define XCHAL__9(a,b,c,d,e,f,g,h,i, x, ...) x
+#define XCHAL__10(a,b,c,d,e,f,g,h,i,j, x, ...) x
+#define XCHAL__11(a,b,c,d,e,f,g,h,i,j,k, x, ...) x
+#define XCHAL__12(a,b,c,d,e,f,g,h,i,j,k,l, x, ...) x
+#define XCHAL__13(a,b,c,d,e,f,g,h,i,j,k,l,m, x, ...) x
+#define XCHAL__14(a,b,c,d,e,f,g,h,i,j,k,l,m,n, x, ...) x
+#define XCHAL__15(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o, x, ...) x
+#define XCHAL__16(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p, x, ...) x
+#define XCHAL__17(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q, x, ...) x
+#define XCHAL__18(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r, x, ...) x
+#define XCHAL__19(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s, x, ...) x
+#define XCHAL__SELECT(n, ...) XCHAL__ ## n(__VA_ARGS__)
+#define XCHAL_SELECT(n, ...)  XCHAL_EXPAND(XCHAL__SELECT(n, __VA_ARGS__))
+/* parasoft-end-suppress MISRA2012-RULE-20_7 "enclosing 'x' in parenthesis not appropriate when argument is __VA_ARGS__" */
+
+
+/*----------------------------------------------------------------------
+                                ERRATA
+  ----------------------------------------------------------------------*/
+
+/*
+ *  Erratum T1020.H13, T1030.H7, T1040.H10, T1050.H4 (fixed in T1040.3 and T1050.1;
+ *  relevant only in XEA1, kernel-vector mode, level-one interrupts and overflows enabled):
+ */
+#define XCHAL_MAYHAVE_ERRATUM_XEA1KWIN  (XCHAL_HAVE_XEA1 && \
+                                         (XCHAL_HW_RELEASE_AT_OR_BELOW(1040,2) != 0 \
+                                          || XCHAL_HW_RELEASE_AT(1050,0)))
+/*
+ *  Erratum 453 present in RE-2013.2 up to RF-2014.0, fixed in RF-2014.1.
+ *  Applies to specific set of configuration options.
+ *  Part of the workaround is to add ISYNC at certain points in the code.
+ *  The workaround gated by this macro can be disabled if not needed, e.g. if
+ *  zero-overhead loop buffer will be disabled, by defining _NO_ERRATUM_453.
+ */
+#if (   XCHAL_HW_MAX_VERSION >= XTENSA_HWVERSION_RE_2013_2 && \
+        XCHAL_HW_MIN_VERSION <= XTENSA_HWVERSION_RF_2014_0 && \
+        XCHAL_ICACHE_SIZE != 0    && XCHAL_HAVE_PIF /*covers also AXI/AHB*/ && \
+        XCHAL_HAVE_LOOPS          && XCHAL_LOOP_BUFFER_SIZE != 0 && \
+        XCHAL_CLOCK_GATING_GLOBAL && !defined(_NO_ERRATUM_453) )
+#define XCHAL_ERRATUM_453       1
+#else
+#define XCHAL_ERRATUM_453       0
+#endif
+
+/*
+ *  Erratum 497 present in RE-2012.2 up to RG/RF-2015.2
+ *  Applies to specific set of configuration options.
+ *  Workaround is to add MEMWs after at most 8 cache WB instructions
+ */
+#if ( ((XCHAL_HW_MAX_VERSION >= XTENSA_HWVERSION_RE_2012_0 &&    \
+        XCHAL_HW_MIN_VERSION <= XTENSA_HWVERSION_RF_2015_2) ||   \
+       (XCHAL_HW_MAX_VERSION >= XTENSA_HWVERSION_RG_2015_0 &&    \
+        XCHAL_HW_MIN_VERSION <= XTENSA_HWVERSION_RG_2015_2)     \
+      ) && \
+      XCHAL_DCACHE_IS_WRITEBACK && \
+      XCHAL_HAVE_AXI && \
+      XCHAL_HAVE_PIF_WR_RESP && \
+      XCHAL_HAVE_PIF_REQ_ATTR &&  !defined(_NO_ERRATUM_497) \
+    )
+#define XCHAL_ERRATUM_497       1
+#else
+#define XCHAL_ERRATUM_497       0
+#endif
+
+
+/*----------------------------------------------------------------------
+				ISA
+  ----------------------------------------------------------------------*/
+
+#if XCHAL_HAVE_BE
+# define XCHAL_HAVE_LE			0
+# define XCHAL_MEMORY_ORDER		XTHAL_BIGENDIAN
+#else
+# define XCHAL_HAVE_LE			1
+# define XCHAL_MEMORY_ORDER		XTHAL_LITTLEENDIAN
+#endif
+
+
+
+/*----------------------------------------------------------------------
+				INTERRUPTS
+  ----------------------------------------------------------------------*/
+
+/*  Indexing macros:  */
+#define I_XCHAL_INTLEVEL_MASK(n)		XCHAL_INTLEVEL ## n ## _MASK
+#define XCHAL_INTLEVEL_MASK(n)			I_XCHAL_INTLEVEL_MASK(n)		/* n = 0 .. 15 */
+#define I_XCHAL_INTLEVEL_ANDBELOWMASK(n)	XCHAL_INTLEVEL ## n ## _ANDBELOW_MASK
+#define XCHAL_INTLEVEL_ANDBELOW_MASK(n)		I_XCHAL_INTLEVEL_ANDBELOWMASK(n)	/* n = 0 .. 15 */
+#define I_XCHAL_INTLEVEL_NUM(n)			XCHAL_INTLEVEL ## n ## _NUM
+#define XCHAL_INTLEVEL_NUM(n)			I_XCHAL_INTLEVEL_NUM(n)			/* n = 0 .. 15 */
+#define I_XCHAL_INT_LEVEL(n)			XCHAL_INT ## n ## _LEVEL
+#define XCHAL_INT_LEVEL(n)			I_XCHAL_INT_LEVEL(n)			/* n = 0 .. 31 */
+#define I_XCHAL_INT_TYPE(n)			XCHAL_INT ## n ## _TYPE
+#define XCHAL_INT_TYPE(n)			I_XCHAL_INT_TYPE(n)			/* n = 0 .. 31 */
+#define I_XCHAL_TIMER_INTERRUPT(n)		XCHAL_TIMER ## n ## _INTERRUPT
+#define XCHAL_TIMER_INTERRUPT(n)		I_XCHAL_TIMER_INTERRUPT(n)		/* n = 0 .. 3 */
+
+
+#define XCHAL_HAVE_HIGHLEVEL_INTERRUPTS	XCHAL_HAVE_HIGHPRI_INTERRUPTS
+#define XCHAL_NUM_LOWPRI_LEVELS		1			/* number of low-priority interrupt levels (always 1) */
+#define XCHAL_FIRST_HIGHPRI_LEVEL	(XCHAL_NUM_LOWPRI_LEVELS+1)	/* level of first high-priority interrupt (always 2) */
+/*  Note:  1 <= LOWPRI_LEVELS <= EXCM_LEVEL < DEBUGLEVEL <= NUM_INTLEVELS < NMILEVEL <= 15  */
+
+/*  These values are constant for existing Xtensa processor implementations:  */
+#if (XCHAL_HAVE_XEA1 || XCHAL_HAVE_XEA2)
+
+#define XCHAL_INTLEVEL0_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL8_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL9_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL10_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL11_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL12_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL13_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL14_MASK		UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL15_MASK		UINT32_C(0x00000000)
+
+/*  Array of masks of interrupts at each interrupt level:  */
+#define XCHAL_INTLEVEL_MASKS		XCHAL_INTLEVEL0_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL1_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL2_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL3_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL4_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL5_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL6_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL7_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL8_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL9_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL10_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL11_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL12_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL13_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL14_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL15_MASK
+
+/*  These values are constant for existing Xtensa processor implementations:  */
+#define XCHAL_INTLEVEL0_ANDBELOW_MASK	UINT32_C(0x00000000)
+#define XCHAL_INTLEVEL8_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+#define XCHAL_INTLEVEL9_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+#define XCHAL_INTLEVEL10_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+#define XCHAL_INTLEVEL11_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+#define XCHAL_INTLEVEL12_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+#define XCHAL_INTLEVEL13_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+#define XCHAL_INTLEVEL14_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+#define XCHAL_INTLEVEL15_ANDBELOW_MASK	XCHAL_INTLEVEL7_ANDBELOW_MASK
+
+/*  Mask of all low-priority interrupts:  */
+#define XCHAL_LOWPRI_MASK		XCHAL_INTLEVEL1_ANDBELOW_MASK
+
+/*  Mask of all interrupts masked by PS.EXCM (or CEXCM):  */
+#define XCHAL_EXCM_MASK			XCHAL_INTLEVEL_ANDBELOW_MASK(XCHAL_EXCM_LEVEL)
+
+/*  Array of masks of interrupts at each range 1..n of interrupt levels:  */
+#define XCHAL_INTLEVEL_ANDBELOW_MASKS	XCHAL_INTLEVEL0_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL1_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL2_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL3_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL4_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL5_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL6_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL7_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL8_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL9_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL10_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL11_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL12_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL13_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL14_ANDBELOW_MASK \
+			XCHAL_SEP	XCHAL_INTLEVEL15_ANDBELOW_MASK
+
+#if 0 /*XCHAL_HAVE_NMI*/
+/*  NMI "interrupt level" (for use with EXCSAVE_n, EPS_n, EPC_n, RFI n):  */
+# define XCHAL_NMILEVEL		(XCHAL_NUM_INTLEVELS+1)
+#endif
+
+/*  Array of levels of each possible interrupt:  */
+#define XCHAL_INT_LEVELS		XCHAL_INT0_LEVEL \
+			XCHAL_SEP	XCHAL_INT1_LEVEL \
+			XCHAL_SEP	XCHAL_INT2_LEVEL \
+			XCHAL_SEP	XCHAL_INT3_LEVEL \
+			XCHAL_SEP	XCHAL_INT4_LEVEL \
+			XCHAL_SEP	XCHAL_INT5_LEVEL \
+			XCHAL_SEP	XCHAL_INT6_LEVEL \
+			XCHAL_SEP	XCHAL_INT7_LEVEL \
+			XCHAL_SEP	XCHAL_INT8_LEVEL \
+			XCHAL_SEP	XCHAL_INT9_LEVEL \
+			XCHAL_SEP	XCHAL_INT10_LEVEL \
+			XCHAL_SEP	XCHAL_INT11_LEVEL \
+			XCHAL_SEP	XCHAL_INT12_LEVEL \
+			XCHAL_SEP	XCHAL_INT13_LEVEL \
+			XCHAL_SEP	XCHAL_INT14_LEVEL \
+			XCHAL_SEP	XCHAL_INT15_LEVEL \
+			XCHAL_SEP	XCHAL_INT16_LEVEL \
+			XCHAL_SEP	XCHAL_INT17_LEVEL \
+			XCHAL_SEP	XCHAL_INT18_LEVEL \
+			XCHAL_SEP	XCHAL_INT19_LEVEL \
+			XCHAL_SEP	XCHAL_INT20_LEVEL \
+			XCHAL_SEP	XCHAL_INT21_LEVEL \
+			XCHAL_SEP	XCHAL_INT22_LEVEL \
+			XCHAL_SEP	XCHAL_INT23_LEVEL \
+			XCHAL_SEP	XCHAL_INT24_LEVEL \
+			XCHAL_SEP	XCHAL_INT25_LEVEL \
+			XCHAL_SEP	XCHAL_INT26_LEVEL \
+			XCHAL_SEP	XCHAL_INT27_LEVEL \
+			XCHAL_SEP	XCHAL_INT28_LEVEL \
+			XCHAL_SEP	XCHAL_INT29_LEVEL \
+			XCHAL_SEP	XCHAL_INT30_LEVEL \
+			XCHAL_SEP	XCHAL_INT31_LEVEL
+
+/*  Array of types of each possible interrupt:  */
+#define XCHAL_INT_TYPES			XCHAL_INT0_TYPE \
+			XCHAL_SEP	XCHAL_INT1_TYPE \
+			XCHAL_SEP	XCHAL_INT2_TYPE \
+			XCHAL_SEP	XCHAL_INT3_TYPE \
+			XCHAL_SEP	XCHAL_INT4_TYPE \
+			XCHAL_SEP	XCHAL_INT5_TYPE \
+			XCHAL_SEP	XCHAL_INT6_TYPE \
+			XCHAL_SEP	XCHAL_INT7_TYPE \
+			XCHAL_SEP	XCHAL_INT8_TYPE \
+			XCHAL_SEP	XCHAL_INT9_TYPE \
+			XCHAL_SEP	XCHAL_INT10_TYPE \
+			XCHAL_SEP	XCHAL_INT11_TYPE \
+			XCHAL_SEP	XCHAL_INT12_TYPE \
+			XCHAL_SEP	XCHAL_INT13_TYPE \
+			XCHAL_SEP	XCHAL_INT14_TYPE \
+			XCHAL_SEP	XCHAL_INT15_TYPE \
+			XCHAL_SEP	XCHAL_INT16_TYPE \
+			XCHAL_SEP	XCHAL_INT17_TYPE \
+			XCHAL_SEP	XCHAL_INT18_TYPE \
+			XCHAL_SEP	XCHAL_INT19_TYPE \
+			XCHAL_SEP	XCHAL_INT20_TYPE \
+			XCHAL_SEP	XCHAL_INT21_TYPE \
+			XCHAL_SEP	XCHAL_INT22_TYPE \
+			XCHAL_SEP	XCHAL_INT23_TYPE \
+			XCHAL_SEP	XCHAL_INT24_TYPE \
+			XCHAL_SEP	XCHAL_INT25_TYPE \
+			XCHAL_SEP	XCHAL_INT26_TYPE \
+			XCHAL_SEP	XCHAL_INT27_TYPE \
+			XCHAL_SEP	XCHAL_INT28_TYPE \
+			XCHAL_SEP	XCHAL_INT29_TYPE \
+			XCHAL_SEP	XCHAL_INT30_TYPE \
+			XCHAL_SEP	XCHAL_INT31_TYPE
+
+/*  Array of masks of interrupts for each type of interrupt:  */
+#define XCHAL_INTTYPE_MASKS		XCHAL_INTTYPE_MASK_UNCONFIGURED	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_SOFTWARE	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_EXTERN_EDGE	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_EXTERN_LEVEL	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_TIMER	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_NMI		\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_WRITE_ERROR	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_IDMA_DONE	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_IDMA_ERR	\
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_GS_ERR       \
+			XCHAL_SEP	XCHAL_INTTYPE_MASK_L2_ERR
+
+/*  Interrupts that can be cleared using the INTCLEAR special register:  */
+#define XCHAL_INTCLEARABLE_MASK	(XCHAL_INTTYPE_MASK_SOFTWARE+XCHAL_INTTYPE_MASK_EXTERN_EDGE+XCHAL_INTTYPE_MASK_WRITE_ERROR)
+/*  Interrupts that can be triggered using the INTSET special register:  */
+#define XCHAL_INTSETTABLE_MASK	XCHAL_INTTYPE_MASK_SOFTWARE
+
+
+/*  For backward compatibility and for the array macros, define macros for
+ *  each unconfigured interrupt number (unfortunately, the value of
+ *  XTHAL_INTTYPE_UNCONFIGURED is not zero):  */
+#if XCHAL_NUM_INTERRUPTS == 0
+# define XCHAL_INT0_LEVEL		0
+# define XCHAL_INT0_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 1
+# define XCHAL_INT1_LEVEL		0
+# define XCHAL_INT1_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 2
+# define XCHAL_INT2_LEVEL		0
+# define XCHAL_INT2_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 3
+# define XCHAL_INT3_LEVEL		0
+# define XCHAL_INT3_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 4
+# define XCHAL_INT4_LEVEL		0
+# define XCHAL_INT4_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 5
+# define XCHAL_INT5_LEVEL		0
+# define XCHAL_INT5_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 6
+# define XCHAL_INT6_LEVEL		0
+# define XCHAL_INT6_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 7
+# define XCHAL_INT7_LEVEL		0
+# define XCHAL_INT7_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 8
+# define XCHAL_INT8_LEVEL		0
+# define XCHAL_INT8_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 9
+# define XCHAL_INT9_LEVEL		0
+# define XCHAL_INT9_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 10
+# define XCHAL_INT10_LEVEL		0
+# define XCHAL_INT10_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 11
+# define XCHAL_INT11_LEVEL		0
+# define XCHAL_INT11_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 12
+# define XCHAL_INT12_LEVEL		0
+# define XCHAL_INT12_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 13
+# define XCHAL_INT13_LEVEL		0
+# define XCHAL_INT13_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 14
+# define XCHAL_INT14_LEVEL		0
+# define XCHAL_INT14_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 15
+# define XCHAL_INT15_LEVEL		0
+# define XCHAL_INT15_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 16
+# define XCHAL_INT16_LEVEL		0
+# define XCHAL_INT16_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 17
+# define XCHAL_INT17_LEVEL		0
+# define XCHAL_INT17_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 18
+# define XCHAL_INT18_LEVEL		0
+# define XCHAL_INT18_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 19
+# define XCHAL_INT19_LEVEL		0
+# define XCHAL_INT19_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 20
+# define XCHAL_INT20_LEVEL		0
+# define XCHAL_INT20_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 21
+# define XCHAL_INT21_LEVEL		0
+# define XCHAL_INT21_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 22
+# define XCHAL_INT22_LEVEL		0
+# define XCHAL_INT22_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 23
+# define XCHAL_INT23_LEVEL		0
+# define XCHAL_INT23_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 24
+# define XCHAL_INT24_LEVEL		0
+# define XCHAL_INT24_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 25
+# define XCHAL_INT25_LEVEL		0
+# define XCHAL_INT25_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 26
+# define XCHAL_INT26_LEVEL		0
+# define XCHAL_INT26_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 27
+# define XCHAL_INT27_LEVEL		0
+# define XCHAL_INT27_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 28
+# define XCHAL_INT28_LEVEL		0
+# define XCHAL_INT28_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 29
+# define XCHAL_INT29_LEVEL		0
+# define XCHAL_INT29_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 30
+# define XCHAL_INT30_LEVEL		0
+# define XCHAL_INT30_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+#if XCHAL_NUM_INTERRUPTS <= 31
+# define XCHAL_INT31_LEVEL		0
+# define XCHAL_INT31_TYPE		XTHAL_INTTYPE_UNCONFIGURED
+#endif
+
+
+/*
+ *  Masks and levels corresponding to each *external* interrupt.
+ */
+
+#define XCHAL_EXTINT0_MASK		(UINT32_C(1) << XCHAL_EXTINT0_NUM)
+#define XCHAL_EXTINT0_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT0_NUM)
+#define XCHAL_EXTINT1_MASK		(UINT32_C(1) << XCHAL_EXTINT1_NUM)
+#define XCHAL_EXTINT1_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT1_NUM)
+#define XCHAL_EXTINT2_MASK		(UINT32_C(1) << XCHAL_EXTINT2_NUM)
+#define XCHAL_EXTINT2_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT2_NUM)
+#define XCHAL_EXTINT3_MASK		(UINT32_C(1) << XCHAL_EXTINT3_NUM)
+#define XCHAL_EXTINT3_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT3_NUM)
+#define XCHAL_EXTINT4_MASK		(UINT32_C(1) << XCHAL_EXTINT4_NUM)
+#define XCHAL_EXTINT4_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT4_NUM)
+#define XCHAL_EXTINT5_MASK		(UINT32_C(1) << XCHAL_EXTINT5_NUM)
+#define XCHAL_EXTINT5_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT5_NUM)
+#define XCHAL_EXTINT6_MASK		(UINT32_C(1) << XCHAL_EXTINT6_NUM)
+#define XCHAL_EXTINT6_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT6_NUM)
+#define XCHAL_EXTINT7_MASK		(UINT32_C(1) << XCHAL_EXTINT7_NUM)
+#define XCHAL_EXTINT7_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT7_NUM)
+#define XCHAL_EXTINT8_MASK		(UINT32_C(1) << XCHAL_EXTINT8_NUM)
+#define XCHAL_EXTINT8_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT8_NUM)
+#define XCHAL_EXTINT9_MASK		(UINT32_C(1) << XCHAL_EXTINT9_NUM)
+#define XCHAL_EXTINT9_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT9_NUM)
+#define XCHAL_EXTINT10_MASK		(UINT32_C(1) << XCHAL_EXTINT10_NUM)
+#define XCHAL_EXTINT10_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT10_NUM)
+#define XCHAL_EXTINT11_MASK		(UINT32_C(1) << XCHAL_EXTINT11_NUM)
+#define XCHAL_EXTINT11_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT11_NUM)
+#define XCHAL_EXTINT12_MASK		(UINT32_C(1) << XCHAL_EXTINT12_NUM)
+#define XCHAL_EXTINT12_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT12_NUM)
+#define XCHAL_EXTINT13_MASK		(UINT32_C(1) << XCHAL_EXTINT13_NUM)
+#define XCHAL_EXTINT13_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT13_NUM)
+#define XCHAL_EXTINT14_MASK		(UINT32_C(1) << XCHAL_EXTINT14_NUM)
+#define XCHAL_EXTINT14_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT14_NUM)
+#define XCHAL_EXTINT15_MASK		(UINT32_C(1) << XCHAL_EXTINT15_NUM)
+#define XCHAL_EXTINT15_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT15_NUM)
+#define XCHAL_EXTINT16_MASK		(UINT32_C(1) << XCHAL_EXTINT16_NUM)
+#define XCHAL_EXTINT16_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT16_NUM)
+#define XCHAL_EXTINT17_MASK		(UINT32_C(1) << XCHAL_EXTINT17_NUM)
+#define XCHAL_EXTINT17_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT17_NUM)
+#define XCHAL_EXTINT18_MASK		(UINT32_C(1) << XCHAL_EXTINT18_NUM)
+#define XCHAL_EXTINT18_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT18_NUM)
+#define XCHAL_EXTINT19_MASK		(UINT32_C(1) << XCHAL_EXTINT19_NUM)
+#define XCHAL_EXTINT19_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT19_NUM)
+#define XCHAL_EXTINT20_MASK		(UINT32_C(1) << XCHAL_EXTINT20_NUM)
+#define XCHAL_EXTINT20_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT20_NUM)
+#define XCHAL_EXTINT21_MASK		(UINT32_C(1) << XCHAL_EXTINT21_NUM)
+#define XCHAL_EXTINT21_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT21_NUM)
+#define XCHAL_EXTINT22_MASK		(UINT32_C(1) << XCHAL_EXTINT22_NUM)
+#define XCHAL_EXTINT22_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT22_NUM)
+#define XCHAL_EXTINT23_MASK		(UINT32_C(1) << XCHAL_EXTINT23_NUM)
+#define XCHAL_EXTINT23_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT23_NUM)
+#define XCHAL_EXTINT24_MASK		(UINT32_C(1) << XCHAL_EXTINT24_NUM)
+#define XCHAL_EXTINT24_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT24_NUM)
+#define XCHAL_EXTINT25_MASK		(UINT32_C(1) << XCHAL_EXTINT25_NUM)
+#define XCHAL_EXTINT25_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT25_NUM)
+#define XCHAL_EXTINT26_MASK		(UINT32_C(1) << XCHAL_EXTINT26_NUM)
+#define XCHAL_EXTINT26_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT26_NUM)
+#define XCHAL_EXTINT27_MASK		(UINT32_C(1) << XCHAL_EXTINT27_NUM)
+#define XCHAL_EXTINT27_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT27_NUM)
+#define XCHAL_EXTINT28_MASK		(UINT32_C(1) << XCHAL_EXTINT28_NUM)
+#define XCHAL_EXTINT28_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT28_NUM)
+#define XCHAL_EXTINT29_MASK		(UINT32_C(1) << XCHAL_EXTINT29_NUM)
+#define XCHAL_EXTINT29_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT29_NUM)
+#define XCHAL_EXTINT30_MASK		(UINT32_C(1) << XCHAL_EXTINT30_NUM)
+#define XCHAL_EXTINT30_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT30_NUM)
+#define XCHAL_EXTINT31_MASK		(UINT32_C(1) << XCHAL_EXTINT31_NUM)
+#define XCHAL_EXTINT31_LEVEL		XCHAL_INT_LEVEL(XCHAL_EXTINT31_NUM)
+
+#endif /* (XCHAL_HAVE_XEA1 || XCHAL_HAVE_XEA2) */
+
+/*  Array of interrupts assigned to each timer (CCOMPARE0 to CCOMPARE3):  */
+#define XCHAL_TIMER_INTERRUPTS		XCHAL_TIMER0_INTERRUPT \
+			XCHAL_SEP	XCHAL_TIMER1_INTERRUPT \
+			XCHAL_SEP	XCHAL_TIMER2_INTERRUPT \
+			XCHAL_SEP	XCHAL_TIMER3_INTERRUPT
+
+
+/*----------------------------------------------------------------------
+			EXCEPTIONS and VECTORS
+  ----------------------------------------------------------------------*/
+
+#if (XCHAL_HAVE_XEA1 || XCHAL_HAVE_XEA2)
+
+/*  For backward compatibility ONLY -- DO NOT USE (will be removed in future release):  */
+#ifdef XCHAL_USER_VECTOR_VADDR
+#define XCHAL_PROGRAMEXC_VECTOR_VADDR	XCHAL_USER_VECTOR_VADDR
+#define XCHAL_USEREXC_VECTOR_VADDR	XCHAL_USER_VECTOR_VADDR
+#endif
+#ifdef XCHAL_USER_VECTOR_PADDR
+# define XCHAL_PROGRAMEXC_VECTOR_PADDR	XCHAL_USER_VECTOR_PADDR
+# define XCHAL_USEREXC_VECTOR_PADDR	XCHAL_USER_VECTOR_PADDR
+#endif
+#ifdef XCHAL_KERNEL_VECTOR_VADDR
+# define XCHAL_STACKEDEXC_VECTOR_VADDR	XCHAL_KERNEL_VECTOR_VADDR
+# define XCHAL_KERNELEXC_VECTOR_VADDR	XCHAL_KERNEL_VECTOR_VADDR
+#endif
+#ifdef XCHAL_KERNEL_VECTOR_PADDR
+# define XCHAL_STACKEDEXC_VECTOR_PADDR	XCHAL_KERNEL_VECTOR_PADDR
+# define XCHAL_KERNELEXC_VECTOR_PADDR	XCHAL_KERNEL_VECTOR_PADDR
+#endif
+
+/*  Indexing macros:  */
+#define I_XCHAL_INTLEVEL_VECTOR_VADDR(n)	XCHAL_INTLEVEL ## n ## _VECTOR_VADDR
+#define XCHAL_INTLEVEL_VECTOR_VADDR(n)		I_XCHAL_INTLEVEL_VECTOR_VADDR(n)	/* n = 0 .. 15 */
+
+#endif /* XCHAL_HAVE_XEA1 || XCHAL_HAVE_XEA2 */
+
+
+/*----------------------------------------------------------------------
+				DEPRECATED
+	(but still used by RTOS ports etc.)
+  ----------------------------------------------------------------------*/
+/*  PS (special register number 230):  */
+#define XCHAL_PS_VALIDMASK		0x00070F3F
+#define XCHAL_PS_INTLEVEL_BITS		4
+#define XCHAL_PS_INTLEVEL_NUM		16
+#define XCHAL_PS_INTLEVEL_SHIFT		0
+#define XCHAL_PS_INTLEVEL_MASK		0x0000000F
+#define XCHAL_PS_EXCM_BITS		1
+#define XCHAL_PS_EXCM_NUM		2
+#define XCHAL_PS_EXCM_SHIFT		4
+#define XCHAL_PS_EXCM_MASK		0x00000010
+#define XCHAL_PS_UM_BITS		1
+#define XCHAL_PS_UM_NUM			2
+#define XCHAL_PS_UM_SHIFT		5
+#define XCHAL_PS_UM_MASK		0x00000020
+#define XCHAL_PS_RING_BITS		2
+#define XCHAL_PS_RING_NUM		4
+#define XCHAL_PS_RING_SHIFT		6
+#define XCHAL_PS_RING_MASK		0x000000C0
+#define XCHAL_PS_OWB_BITS		4
+#define XCHAL_PS_OWB_NUM		16
+#define XCHAL_PS_OWB_SHIFT		8
+#define XCHAL_PS_OWB_MASK		0x00000F00
+#define XCHAL_PS_CALLINC_BITS		2
+#define XCHAL_PS_CALLINC_NUM		4
+#define XCHAL_PS_CALLINC_SHIFT		16
+#define XCHAL_PS_CALLINC_MASK		0x00030000
+#define XCHAL_PS_WOE_BITS		1
+#define XCHAL_PS_WOE_NUM		2
+#define XCHAL_PS_WOE_SHIFT		18
+#define XCHAL_PS_WOE_MASK		0x00040000
+
+
+/*----------------------------------------------------------------------
+				TIMERS
+  ----------------------------------------------------------------------*/
+
+
+/*----------------------------------------------------------------------
+			INTERNAL I/D RAM/ROMs and XLMI
+  ----------------------------------------------------------------------*/
+
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+
+/*  Default PREFCTL value to enable prefetch.  */
+#if XCHAL_HW_MIN_VERSION < XTENSA_HWVERSION_RE_2012_0
+#define XCHAL_CACHE_PREFCTL_DEFAULT	UINT32_C(0x00044)	/* enabled, not aggressive */
+#elif XCHAL_HW_MIN_VERSION < XTENSA_HWVERSION_RF_2014_0
+#define XCHAL_CACHE_PREFCTL_DEFAULT	UINT32_C(0x01044)	/* + enable prefetch to L1 */
+#elif ((XCHAL_PREFETCH_ENTRIES >= 16) && XCHAL_HAVE_CACHE_BLOCKOPS)
+#define XCHAL_CACHE_PREFCTL_DEFAULT	UINT32_C(0x81044)	/* 12 entries for block ops */
+#elif ((XCHAL_PREFETCH_ENTRIES >= 8) && XCHAL_HAVE_CACHE_BLOCKOPS)
+#define XCHAL_CACHE_PREFCTL_DEFAULT	UINT32_C(0x51044)	/* 5 entries for block ops */
+#else
+#define XCHAL_CACHE_PREFCTL_DEFAULT	UINT32_C(0x01044)	/* 0 entries for block ops */
+#endif
+
+
+/*  Max for both I-cache and D-cache (used for general alignment):  */
+#if XCHAL_ICACHE_LINESIZE > XCHAL_DCACHE_LINESIZE
+# define XCHAL_CACHE_LINEWIDTH_MAX	XCHAL_ICACHE_LINEWIDTH
+# define XCHAL_CACHE_LINESIZE_MAX	XCHAL_ICACHE_LINESIZE
+#else
+# define XCHAL_CACHE_LINEWIDTH_MAX	XCHAL_DCACHE_LINEWIDTH
+# define XCHAL_CACHE_LINESIZE_MAX	XCHAL_DCACHE_LINESIZE
+#endif
+
+#define XCHAL_ICACHE_SETSIZE		(UINT32_C(1) << XCHAL_ICACHE_SETWIDTH)
+#define XCHAL_DCACHE_SETSIZE		(UINT32_C(1) << XCHAL_DCACHE_SETWIDTH)
+/*  Max for both I and D caches (used for cache-coherency page alignment):  */
+#if XCHAL_ICACHE_SETWIDTH > XCHAL_DCACHE_SETWIDTH
+# define XCHAL_CACHE_SETWIDTH_MAX	XCHAL_ICACHE_SETWIDTH
+# define XCHAL_CACHE_SETSIZE_MAX	XCHAL_ICACHE_SETSIZE
+#else
+# define XCHAL_CACHE_SETWIDTH_MAX	XCHAL_DCACHE_SETWIDTH
+# define XCHAL_CACHE_SETSIZE_MAX	XCHAL_DCACHE_SETSIZE
+#endif
+
+/*  Instruction cache tag bits:  */
+#define XCHAL_ICACHE_TAG_V_SHIFT	0
+#define XCHAL_ICACHE_TAG_V		0x1	/* valid bit */
+#if XCHAL_ICACHE_WAYS > 1
+# define XCHAL_ICACHE_TAG_F_SHIFT	1
+# define XCHAL_ICACHE_TAG_F		0x2	/* fill (LRU) bit */
+#else
+# define XCHAL_ICACHE_TAG_F_SHIFT	0
+# define XCHAL_ICACHE_TAG_F		0	/* no fill (LRU) bit */
+#endif
+#if XCHAL_ICACHE_LINE_LOCKABLE
+# define XCHAL_ICACHE_TAG_L_SHIFT	(XCHAL_ICACHE_TAG_F_SHIFT+1)
+# define XCHAL_ICACHE_TAG_L		(UINT32_C(1) << XCHAL_ICACHE_TAG_L_SHIFT)	/* lock bit */
+#else
+# define XCHAL_ICACHE_TAG_L_SHIFT	XCHAL_ICACHE_TAG_F_SHIFT
+# define XCHAL_ICACHE_TAG_L		0	/* no lock bit */
+#endif
+/*  Data cache tag bits:  */
+#define XCHAL_DCACHE_TAG_V_SHIFT	0
+#define XCHAL_DCACHE_TAG_V		0x1	/* valid bit */
+#if XCHAL_DCACHE_WAYS > 1
+# define XCHAL_DCACHE_TAG_F_SHIFT	1
+# define XCHAL_DCACHE_TAG_F		0x2	/* fill (LRU) bit */
+#else
+# define XCHAL_DCACHE_TAG_F_SHIFT	0
+# define XCHAL_DCACHE_TAG_F		0	/* no fill (LRU) bit */
+#endif
+#if XCHAL_DCACHE_IS_WRITEBACK
+# define XCHAL_DCACHE_TAG_D_SHIFT	(XCHAL_DCACHE_TAG_F_SHIFT+1)
+# define XCHAL_DCACHE_TAG_D		(UINT32_C(1) << XCHAL_DCACHE_TAG_D_SHIFT)	/* dirty bit */
+#else
+# define XCHAL_DCACHE_TAG_D_SHIFT	XCHAL_DCACHE_TAG_F_SHIFT
+# define XCHAL_DCACHE_TAG_D		0	/* no dirty bit */
+#endif
+#if XCHAL_DCACHE_LINE_LOCKABLE
+# define XCHAL_DCACHE_TAG_L_SHIFT	(XCHAL_DCACHE_TAG_D_SHIFT+1)
+# define XCHAL_DCACHE_TAG_L		(UINT32_C(1) << XCHAL_DCACHE_TAG_L_SHIFT)	/* lock bit */
+#else
+# define XCHAL_DCACHE_TAG_L_SHIFT	XCHAL_DCACHE_TAG_D_SHIFT
+# define XCHAL_DCACHE_TAG_L		0	/* no lock bit */
+#endif
+
+/*  Whether MEMCTL register has anything useful  */
+#define XCHAL_USE_MEMCTL		(((XCHAL_LOOP_BUFFER_SIZE > 0)	||      \
+					XCHAL_DCACHE_IS_COHERENT	||      \
+					XCHAL_HAVE_BRANCH_PREDICTION	||      \
+					XCHAL_HAVE_ICACHE_DYN_ENABLE	||      \
+					XCHAL_HAVE_DCACHE_DYN_ENABLE)	&&      \
+					(XCHAL_HW_MIN_VERSION >= XTENSA_HWVERSION_RE_2012_0))
+
+/*  Default MEMCTL values:  */
+#if XCHAL_HAVE_ICACHE_DYN_ENABLE || XCHAL_HAVE_DCACHE_DYN_ENABLE || XCHAL_HAVE_CME_DOWNGRADES
+#define XCHAL_CACHE_MEMCTL_DEFAULT	UINT32_C(0xFFFFFF08)	/* init all possible ways */
+#else
+#define XCHAL_CACHE_MEMCTL_DEFAULT	UINT32_C(0x00000000)	/* nothing to do */
+#endif
+
+#if XCHAL_DCACHE_IS_COHERENT
+#define XCHAL_MEMCTL_SNOOP_EN		UINT32_C(0x02)	/* enable snoop */
+#else
+#define XCHAL_MEMCTL_SNOOP_EN		UINT32_C(0x00)	/* don't enable snoop */
+#endif
+
+#if (XCHAL_LOOP_BUFFER_SIZE == 0) || XCHAL_ERRATUM_453
+#define XCHAL_MEMCTL_L0IBUF_EN		UINT32_C(0x00)	/* no loop buffer or don't enable */
+#else
+#define XCHAL_MEMCTL_L0IBUF_EN		UINT32_C(0x01)	/* enable loop buffer */
+#endif
+
+#if XCHAL_HAVE_BRANCH_PREDICTION
+#define XCHAL_MEMCTL_BP_EN		UINT32_C(0x08)	/* enable branch prediction */
+#else
+#define XCHAL_MEMCTL_BP_EN		UINT32_C(0x00)	/* don't enable BP */
+#endif
+
+#define XCHAL_MEMCTL_DEFAULT		XCHAL_CACHE_MEMCTL_DEFAULT
+#define XCHAL_MEMCTL_DEFAULT_POST	(XCHAL_MEMCTL_SNOOP_EN | XCHAL_MEMCTL_L0IBUF_EN | XCHAL_MEMCTL_BP_EN)
+
+
+/*----------------------------------------------------------------------
+				MMU
+  ----------------------------------------------------------------------*/
+
+/*  See <xtensa/config/core-matmap.h> for more details.  */
+
+/*  Indexing macros:  */
+/*  parasoft-begin-suppress MISRA2012-RULE-20_7 "Cannot parenthesize macro args here" */
+#define I_XCHAL_ITLB_SET(n,_what)	XCHAL_ITLB_SET ## n ## _what
+#define XCHAL_ITLB_SET(n,what)		I_XCHAL_ITLB_SET(n, _ ## what )
+#define I_XCHAL_ITLB_SET_E(n,i,_what)	XCHAL_ITLB_SET ## n ## _E ## i ## _what
+#define XCHAL_ITLB_SET_E(n,i,what)	I_XCHAL_ITLB_SET_E(n,i, _ ## what )
+#define I_XCHAL_DTLB_SET(n,_what)	XCHAL_DTLB_SET ## n ## _what
+#define XCHAL_DTLB_SET(n,what)		I_XCHAL_DTLB_SET(n, _ ## what )
+#define I_XCHAL_DTLB_SET_E(n,i,_what)	XCHAL_DTLB_SET ## n ## _E ## i ## _what
+#define XCHAL_DTLB_SET_E(n,i,what)	I_XCHAL_DTLB_SET_E(n,i, _ ## what )
+/*  parasoft-end-suppress MISRA2012-RULE-20_7  "Cannot parenthesize macro args here" */
+/*
+ *  Example use:  XCHAL_ITLB_SET(XCHAL_ITLB_ARF_SET0,ENTRIES)
+ *	to get the value of XCHAL_ITLB_SET<n>_ENTRIES where <n> is the first auto-refill set.
+ */
+
+/*  Number of entries per autorefill way:  */
+#define XCHAL_ITLB_ARF_ENTRIES		(UINT32_C(1) << XCHAL_ITLB_ARF_ENTRIES_LOG2)
+#define XCHAL_DTLB_ARF_ENTRIES		(UINT32_C(1) << XCHAL_DTLB_ARF_ENTRIES_LOG2)
+
+/*
+ *  For full MMUs, report kernel RAM segment and kernel I/O segment static page mappings:
+ */
+#if XCHAL_HAVE_PTP_MMU && !XCHAL_HAVE_SPANNING_WAY
+#define XCHAL_KSEG_CACHED_VADDR		UINT32_C(0xD0000000)	/* virt.addr of kernel RAM cached static map */
+#define XCHAL_KSEG_CACHED_PADDR		UINT32_C(0x00000000)	/* phys.addr of kseg_cached */
+#define XCHAL_KSEG_CACHED_SIZE		UINT32_C(0x08000000)	/* size in bytes of kseg_cached (assumed power of 2!!!) */
+#define XCHAL_KSEG_BYPASS_VADDR		UINT32_C(0xD8000000)	/* virt.addr of kernel RAM bypass (uncached) static map */
+#define XCHAL_KSEG_BYPASS_PADDR		UINT32_C(0x00000000)	/* phys.addr of kseg_bypass */
+#define XCHAL_KSEG_BYPASS_SIZE		UINT32_C(0x08000000)	/* size in bytes of kseg_bypass (assumed power of 2!!!) */
+
+#define XCHAL_KIO_CACHED_VADDR		UINT32_C(0xE0000000)	/* virt.addr of kernel I/O cached static map */
+#define XCHAL_KIO_CACHED_PADDR		UINT32_C(0xF0000000)	/* phys.addr of kio_cached */
+#define XCHAL_KIO_CACHED_SIZE		UINT32_C(0x10000000)	/* size in bytes of kio_cached (assumed power of 2!!!) */
+#define XCHAL_KIO_BYPASS_VADDR		UINT32_C(0xF0000000)	/* virt.addr of kernel I/O bypass (uncached) static map */
+#define XCHAL_KIO_BYPASS_PADDR		UINT32_C(0xF0000000)	/* phys.addr of kio_bypass */
+#define XCHAL_KIO_BYPASS_SIZE		UINT32_C(0x10000000)	/* size in bytes of kio_bypass (assumed power of 2!!!) */
+
+#define XCHAL_SEG_MAPPABLE_VADDR	UINT32_C(0x00000000)	/* start of largest non-static-mapped virtual addr area */
+#define XCHAL_SEG_MAPPABLE_SIZE		UINT32_C(0xD0000000)	/* size in bytes of  "  */
+/* define XCHAL_SEG_MAPPABLE2_xxx if more areas present, sorted in order of descending size.  */
+#endif
+
+
+#if XCHAL_HAVE_MPU && XCHAL_HAVE_LX && XCHAL_HAVE_XEA2
+#define XCHAL_HAVE_CACHEADRDIS		1		/* CACHEADRDIS register present */
+#else
+#define XCHAL_HAVE_CACHEADRDIS		0
+#endif
+
+#if XCHAL_HAVE_APB && defined(XTENSA_HWVERSION_NX1_1_0) && \
+    (XCHAL_HW_VERSION >= XTENSA_HWVERSION_NX1_1_0)
+#define XCHAL_HAVE_PROGRAMMABLE_APB	1
+#else
+#define XCHAL_HAVE_PROGRAMMABLE_APB	0
+#endif
+
+/*----------------------------------------------------------------------
+				MISC
+  ----------------------------------------------------------------------*/
+
+/*  Data alignment required if used for instructions:  */
+#if XCHAL_INST_FETCH_WIDTH > XCHAL_DATA_WIDTH
+# define XCHAL_ALIGN_MAX		XCHAL_INST_FETCH_WIDTH
+#else
+# define XCHAL_ALIGN_MAX		XCHAL_DATA_WIDTH
+#endif
+
+/*
+ *  Names kept for backward compatibility.
+ *  (Here "RELEASE" is now a misnomer; these are product *versions*, not the releases
+ *   under which they are released.  In the T10##.# era there was no distinction.)
+ */
+#define XCHAL_HW_RELEASE_MAJOR		XCHAL_HW_VERSION_MAJOR
+#define XCHAL_HW_RELEASE_MINOR		XCHAL_HW_VERSION_MINOR
+#define XCHAL_HW_RELEASE_NAME		XCHAL_HW_VERSION_NAME
+
+/*  The condition for the existence of the ATOMCTL register. */
+#define XCHAL_HAVE_ATOMCTL		(XCHAL_HAVE_EXCLUSIVE || \
+					(XCHAL_HAVE_S32C1I    && \
+					(XCHAL_HW_MIN_VERSION >= XTENSA_HWVERSION_RC_2009_0)))
+
+
+/*----------------------------------------------------------------------
+			COPROCESSORS and EXTRA STATE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_EXTRA_SA_SIZE		XCHAL_NCP_SA_SIZE
+#define XCHAL_EXTRA_SA_ALIGN		XCHAL_NCP_SA_ALIGN
+#define XCHAL_CPEXTRA_SA_SIZE		XCHAL_TOTAL_SA_SIZE
+#define XCHAL_CPEXTRA_SA_ALIGN		XCHAL_TOTAL_SA_ALIGN
+
+#if defined (_ASMLANGUAGE) || defined (__ASSEMBLER__)
+
+	/*  Invoked at start of save area load/store sequence macro to setup macro
+	 *  internal offsets.  Not usually invoked directly.
+	 *	continue	0 for 1st sequence, 1 for subsequent consecutive ones.
+	 *	totofs		offset from original ptr to next load/store location.
+	 */
+	.macro	xchal_sa_start	continue totofs
+	.ifeq \continue
+	 .set	.Lxchal_pofs_, 0	/* offset from original ptr to current \ptr */
+	 .set	.Lxchal_ofs_, 0		/* offset from current \ptr to next load/store location */
+	.endif
+	.if \totofs + 1			/* if totofs specified (not -1) */
+	 .set	.Lxchal_ofs_, \totofs - .Lxchal_pofs_	/* specific offset from original ptr */
+	.endif
+	.endm
+
+	/*  Align portion of save area and bring ptr in range if necessary.
+	 *  Used by save area load/store sequences.  Not usually invoked directly.
+	 *  Allows combining multiple (sub-)sequences arbitrarily.
+	 *	ptr		pointer to save area (may be off, see .Lxchal_pofs_)
+	 *	minofs,maxofs	range of offset from cur ptr to next load/store loc;
+	 *			minofs <= 0 <= maxofs  (0 must always be valid offset)
+	 *			range must be within +/- 30kB or so.
+	 *	ofsalign	alignment granularity of minofs .. maxofs (pow of 2)
+	 *			(restriction on offset from ptr to next load/store loc)
+	 *	totalign	align from orig ptr to next load/store loc (pow of 2)
+	 */
+	.macro	xchal_sa_align	ptr minofs maxofs ofsalign totalign
+	/*  First align where we start accessing the next register
+	 *  per \totalign relative to original ptr (i.e. start of the save area):
+	 */
+	.set	.Lxchal_ofs_, ((.Lxchal_pofs_ + .Lxchal_ofs_ + \totalign - 1) & -\totalign) - .Lxchal_pofs_
+	/*  If necessary, adjust \ptr to bring .Lxchal_ofs_ in acceptable range:  */
+	.if (((\maxofs) - .Lxchal_ofs_) & 0xC0000000) | ((.Lxchal_ofs_ - (\minofs)) & 0xC0000000) | (.Lxchal_ofs_ & (\ofsalign-1))
+	 .set	.Ligmask, 0xFFFFFFFF	/* TODO: optimize to addmi, per aligns and .Lxchal_ofs_ */
+	 addi.a	\ptr, \ptr, (.Lxchal_ofs_ & .Ligmask)
+	 .set	.Lxchal_pofs_, .Lxchal_pofs_ + (.Lxchal_ofs_ & .Ligmask)
+	 .set	.Lxchal_ofs_, (.Lxchal_ofs_ & ~.Ligmask)
+	.endif
+	.endm
+	/*
+	 *  We could optimize for addi to expand to only addmi instead of
+	 *  "addmi;addi", where possible.  Here's a partial example how:
+	 * .set	.Lmaxmask, -(\ofsalign) & -(\totalign)
+	 * .if (((\maxofs) + ~.Lmaxmask + 1) & 0xFFFFFF00) && ((.Lxchal_ofs_ & ~.Lmaxmask) == 0)
+	 *  .set	.Ligmask, 0xFFFFFF00
+	 * .elif ... ditto for negative ofs range ...
+	 *  .set .Ligmask, 0xFFFFFF00
+	 *  .set ... adjust per offset ...
+	 * .else
+	 *  .set .Ligmask, 0xFFFFFFFF
+	 * .endif
+	 */
+
+	/*  Invoke this after xchal_XXX_{load,store} macros to restore \ptr.  */
+	.macro	xchal_sa_ptr_restore	ptr
+	.if .Lxchal_pofs_
+	 addi.a	\ptr, \ptr, - .Lxchal_pofs_
+	 .set	.Lxchal_ofs_, .Lxchal_ofs_ + .Lxchal_pofs_
+	 .set	.Lxchal_pofs_, 0
+	.endif
+	.endm
+
+	/*
+	 *  Use as eg:
+	 *	xchal_atmps_store a1, SOMEOFS, XCHAL_SA_NUM_ATMPS, a4, a5
+	 *	xchal_ncp_load a2, a0,a3,a4,a5
+	 *	xchal_atmps_load  a1, SOMEOFS, XCHAL_SA_NUM_ATMPS, a4, a5
+	 *
+	 *  Specify only the ARs you *haven't* saved/restored already, up to 4.
+	 *  They *must* be the *last* ARs (in same order) specified to save area
+	 *  load/store sequences.  In the example above, a0 and a3 were already
+	 *  saved/restored and unused (thus available) but a4 and a5 were not.
+	 */
+#define xchal_atmps_store	xchal_atmps_loadstore s32i,
+#define xchal_atmps_load	xchal_atmps_loadstore l32i,
+	.macro	xchal_atmps_loadstore	inst ptr offset nreq aa=0 ab=0 ac=0 ad=0
+	.set	.Lnsaved_, 0
+	.irp	reg,\aa,\ab,\ac,\ad
+	 .ifeq 0x\reg ; .set .Lnsaved_,.Lnsaved_+1 ; .endif
+	.endr
+	.set	.Laofs_, 0
+	.irp	reg,\aa,\ab,\ac,\ad
+	 .ifgt (\nreq)-.Lnsaved_
+	  \inst	\reg, \ptr, .Laofs_+\offset
+	  .set	.Laofs_,.Laofs_+4
+	  .set	.Lnsaved_,.Lnsaved_+1
+	 .endif
+	.endr
+	.endm
+
+#define xchal_extratie_load		xchal_ncptie_load
+#define xchal_extratie_store		xchal_ncptie_store
+#define xchal_extratie_load_a2		xchal_ncptie_load  a2,a3,a4,a5,a6
+#define xchal_extratie_store_a2		xchal_ncptie_store a2,a3,a4,a5,a6
+#define xchal_extra_load		xchal_ncp_load
+#define xchal_extra_store		xchal_ncp_store
+#define xchal_extra_load_a2		xchal_ncp_load  a2,a3,a4,a5,a6
+#define xchal_extra_store_a2		xchal_ncp_store a2,a3,a4,a5,a6
+#define xchal_extra_load_funcbody	xchal_ncp_load  a2,a3,a4,a5,a6
+#define xchal_extra_store_funcbody	xchal_ncp_store a2,a3,a4,a5,a6
+#define xchal_cp0_store_a2		xchal_cp0_store  a2,a3,a4,a5,a6
+#define xchal_cp0_load_a2		xchal_cp0_load   a2,a3,a4,a5,a6
+#define xchal_cp1_store_a2		xchal_cp1_store  a2,a3,a4,a5,a6
+#define xchal_cp1_load_a2		xchal_cp1_load   a2,a3,a4,a5,a6
+#define xchal_cp2_store_a2		xchal_cp2_store  a2,a3,a4,a5,a6
+#define xchal_cp2_load_a2		xchal_cp2_load   a2,a3,a4,a5,a6
+#define xchal_cp3_store_a2		xchal_cp3_store  a2,a3,a4,a5,a6
+#define xchal_cp3_load_a2		xchal_cp3_load   a2,a3,a4,a5,a6
+#define xchal_cp4_store_a2		xchal_cp4_store  a2,a3,a4,a5,a6
+#define xchal_cp4_load_a2		xchal_cp4_load   a2,a3,a4,a5,a6
+#define xchal_cp5_store_a2		xchal_cp5_store  a2,a3,a4,a5,a6
+#define xchal_cp5_load_a2		xchal_cp5_load   a2,a3,a4,a5,a6
+#define xchal_cp6_store_a2		xchal_cp6_store  a2,a3,a4,a5,a6
+#define xchal_cp6_load_a2		xchal_cp6_load   a2,a3,a4,a5,a6
+#define xchal_cp7_store_a2		xchal_cp7_store  a2,a3,a4,a5,a6
+#define xchal_cp7_load_a2		xchal_cp7_load   a2,a3,a4,a5,a6
+
+/*  Empty placeholder macros for undefined coprocessors:  */
+#if (XCHAL_CP_MASK & ~XCHAL_CP_PORT_MASK) == 0
+# if XCHAL_CP0_SA_SIZE == 0
+	.macro xchal_cp0_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp0_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+# if XCHAL_CP1_SA_SIZE == 0
+	.macro xchal_cp1_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp1_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+# if XCHAL_CP2_SA_SIZE == 0
+	.macro xchal_cp2_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp2_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+# if XCHAL_CP3_SA_SIZE == 0
+	.macro xchal_cp3_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp3_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+# if XCHAL_CP4_SA_SIZE == 0
+	.macro xchal_cp4_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp4_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+# if XCHAL_CP5_SA_SIZE == 0
+	.macro xchal_cp5_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp5_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+# if XCHAL_CP6_SA_SIZE == 0
+	.macro xchal_cp6_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp6_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+# if XCHAL_CP7_SA_SIZE == 0
+	.macro xchal_cp7_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp7_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+# endif
+#endif
+
+	/********************
+	 *  Macros to create functions that save and restore the state of *any* TIE
+	 *  coprocessor (by dynamic index).
+	 */
+
+	/*
+	 *  Macro that expands to the body of a function
+	 *  that stores the selected coprocessor's state (registers etc).
+	 *	Entry:	a2 = ptr to save area in which to save cp state
+	 *		a3 = coprocessor number
+	 *	Exit:	any register a2-a15 (?) may have been clobbered.
+	 */
+	.macro	xchal_cpi_store_funcbody
+#if (XCHAL_CP_MASK & ~XCHAL_CP_PORT_MASK)
+# if XCHAL_CP0_SA_SIZE
+	bnez	a3, 99f
+	xchal_cp0_store_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP1_SA_SIZE
+	bnei	a3, 1, 99f
+	xchal_cp1_store_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP2_SA_SIZE
+	bnei	a3, 2, 99f
+	xchal_cp2_store_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP3_SA_SIZE
+	bnei	a3, 3, 99f
+	xchal_cp3_store_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP4_SA_SIZE
+	bnei	a3, 4, 99f
+	xchal_cp4_store_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP5_SA_SIZE
+	bnei	a3, 5, 99f
+	xchal_cp5_store_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP6_SA_SIZE
+	bnei	a3, 6, 99f
+	xchal_cp6_store_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP7_SA_SIZE
+	bnei	a3, 7, 99f
+	xchal_cp7_store_a2
+99:
+# endif
+90:
+#endif
+	.endm
+
+	/*
+	 *  Macro that expands to the body of a function
+	 *  that loads the selected coprocessor's state (registers etc).
+	 *	Entry:	a2 = ptr to save area from which to restore cp state
+	 *		a3 = coprocessor number
+	 *	Exit:	any register a2-a15 (?) may have been clobbered.
+	 */
+	.macro	xchal_cpi_load_funcbody
+#if (XCHAL_CP_MASK & ~XCHAL_CP_PORT_MASK)
+# if XCHAL_CP0_SA_SIZE
+	bnez	a3, 99f
+	xchal_cp0_load_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP1_SA_SIZE
+	bnei	a3, 1, 99f
+	xchal_cp1_load_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP2_SA_SIZE
+	bnei	a3, 2, 99f
+	xchal_cp2_load_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP3_SA_SIZE
+	bnei	a3, 3, 99f
+	xchal_cp3_load_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP4_SA_SIZE
+	bnei	a3, 4, 99f
+	xchal_cp4_load_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP5_SA_SIZE
+	bnei	a3, 5, 99f
+	xchal_cp5_load_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP6_SA_SIZE
+	bnei	a3, 6, 99f
+	xchal_cp6_load_a2
+#  if (XCHAL_CP_NUM > 1)
+	j	90f
+#  endif
+99:
+# endif
+# if XCHAL_CP7_SA_SIZE
+	bnei	a3, 7, 99f
+	xchal_cp7_load_a2
+99:
+# endif
+90:
+#endif
+	.endm
+
+#endif /*_ASMLANGUAGE or __ASSEMBLER__*/
+
+
+/*  Other default macros for undefined coprocessors:  */
+#ifndef XCHAL_CP0_NAME
+# define XCHAL_CP0_NAME				0
+# define XCHAL_CP0_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP0_SA_CONTENTS_LIBDB		/* empty */
+#endif
+#ifndef XCHAL_CP1_NAME
+# define XCHAL_CP1_NAME				0
+# define XCHAL_CP1_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP1_SA_CONTENTS_LIBDB		/* empty */
+#endif
+#ifndef XCHAL_CP2_NAME
+# define XCHAL_CP2_NAME				0
+# define XCHAL_CP2_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP2_SA_CONTENTS_LIBDB		/* empty */
+#endif
+#ifndef XCHAL_CP3_NAME
+# define XCHAL_CP3_NAME				0
+# define XCHAL_CP3_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP3_SA_CONTENTS_LIBDB		/* empty */
+#endif
+#ifndef XCHAL_CP4_NAME
+# define XCHAL_CP4_NAME				0
+# define XCHAL_CP4_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP4_SA_CONTENTS_LIBDB		/* empty */
+#endif
+#ifndef XCHAL_CP5_NAME
+# define XCHAL_CP5_NAME				0
+# define XCHAL_CP5_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP5_SA_CONTENTS_LIBDB		/* empty */
+#endif
+#ifndef XCHAL_CP6_NAME
+# define XCHAL_CP6_NAME				0
+# define XCHAL_CP6_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP6_SA_CONTENTS_LIBDB		/* empty */
+#endif
+#ifndef XCHAL_CP7_NAME
+# define XCHAL_CP7_NAME				0
+# define XCHAL_CP7_SA_CONTENTS_LIBDB_NUM	0
+# define XCHAL_CP7_SA_CONTENTS_LIBDB		/* empty */
+#endif
+
+#if XCHAL_CP_MASK == 0
+/*  Filler info for unassigned coprocessors, to simplify arrays etc:  */
+#define XCHAL_CP0_SA_SIZE               0
+#define XCHAL_CP0_SA_ALIGN              1
+#define XCHAL_CP1_SA_SIZE               0
+#define XCHAL_CP1_SA_ALIGN              1
+#define XCHAL_CP2_SA_SIZE               0
+#define XCHAL_CP2_SA_ALIGN              1
+#define XCHAL_CP3_SA_SIZE               0
+#define XCHAL_CP3_SA_ALIGN              1
+#define XCHAL_CP4_SA_SIZE               0
+#define XCHAL_CP4_SA_ALIGN              1
+#define XCHAL_CP5_SA_SIZE               0
+#define XCHAL_CP5_SA_ALIGN              1
+#define XCHAL_CP6_SA_SIZE               0
+#define XCHAL_CP6_SA_ALIGN              1
+#define XCHAL_CP7_SA_SIZE               0
+#define XCHAL_CP7_SA_ALIGN              1
+#endif
+
+
+/*  Indexing macros:  */
+#define I_XCHAL_CP_SA_SIZE(n)		XCHAL_CP ## n ## _SA_SIZE
+#define XCHAL_CP_SA_SIZE(n)		I_XCHAL_CP_SA_SIZE(n)	/* n = 0 .. 7 */
+#define I_XCHAL_CP_SA_ALIGN(n)		XCHAL_CP ## n ## _SA_ALIGN
+#define XCHAL_CP_SA_ALIGN(n)		I_XCHAL_CP_SA_ALIGN(n)	/* n = 0 .. 7 */
+
+/*  Link-time HAL global variables that report coprocessor numbers by name
+    (names are case-preserved from the original TIE):  */
+#if !defined(_ASMLANGUAGE) && !defined(_NOCLANGUAGE) && !defined(__ASSEMBLER__)
+# define I_XCJOIN(a,b)	a ## b		/*  parasoft-suppress MISRA2012-RULE-20_7 "Cannot parenthesize macro args here" */
+# define XCJOIN(a,b)	I_XCJOIN(a,b)	/*  parasoft-suppress MISRA2012-RULE-20_7 "Cannot parenthesize macro args here" */
+
+# ifdef XCHAL_CP0_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP0_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP0_IDENT);
+# endif
+# ifdef XCHAL_CP1_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP1_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP1_IDENT);
+# endif
+# ifdef XCHAL_CP2_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP2_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP2_IDENT);
+# endif
+# ifdef XCHAL_CP3_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP3_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP3_IDENT);
+# endif
+# ifdef XCHAL_CP4_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP4_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP4_IDENT);
+# endif
+# ifdef XCHAL_CP5_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP5_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP5_IDENT);
+# endif
+# ifdef XCHAL_CP6_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP6_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP6_IDENT);
+# endif
+# ifdef XCHAL_CP7_NAME
+extern const uint8_t	XCJOIN(Xthal_cp_id_,XCHAL_CP7_IDENT);
+extern const uint32_t	XCJOIN(Xthal_cp_mask_,XCHAL_CP7_IDENT);
+# endif
+#endif
+
+
+
+
+/*----------------------------------------------------------------------
+				DERIVED
+  ----------------------------------------------------------------------*/
+
+#if XCHAL_HAVE_BE
+#define XCHAL_INST_ILLN			0xD60F		/* 2-byte illegal instruction, msb-first */
+#define XCHAL_INST_ILLN_BYTE0		0xD6		/* 2-byte illegal instruction, 1st byte */
+#define XCHAL_INST_ILLN_BYTE1		0x0F		/* 2-byte illegal instruction, 2nd byte */
+#else
+#define XCHAL_INST_ILLN			0xF06D		/* 2-byte illegal instruction, lsb-first */
+#define XCHAL_INST_ILLN_BYTE0		0x6D		/* 2-byte illegal instruction, 1st byte */
+#define XCHAL_INST_ILLN_BYTE1		0xF0		/* 2-byte illegal instruction, 2nd byte */
+#endif
+/*  Belongs in xtensa/hal.h:  */
+#define XTHAL_INST_ILL			0x000000	/* 3-byte illegal instruction */
+
+
+/*
+ *  Because information as to exactly which hardware version is targeted
+ *  by a given software build is not always available, compile-time HAL
+ *  Hardware-Release "_AT" macros are fuzzy (return 0, 1, or XCHAL_MAYBE):
+ *  (Here "RELEASE" is now a misnomer; these are product *versions*, not the releases
+ *   under which they are released.  In the T10##.# era there was no distinction.)
+ */
+/*  parasoft-begin-suppress MISRA2012-RULE-20_7 "Cannot parenthesize macro args here" */
+#if XCHAL_HW_CONFIGID_RELIABLE
+# define XCHAL_HW_RELEASE_AT_OR_BELOW(major,minor)	(XTHAL_REL_LE( XCHAL_HW_VERSION_MAJOR,XCHAL_HW_VERSION_MINOR, major,minor ) ? 1 : 0)
+# define XCHAL_HW_RELEASE_AT_OR_ABOVE(major,minor)	(XTHAL_REL_GE( XCHAL_HW_VERSION_MAJOR,XCHAL_HW_VERSION_MINOR, major,minor ) ? 1 : 0)
+# define XCHAL_HW_RELEASE_AT(major,minor)		(XTHAL_REL_EQ( XCHAL_HW_VERSION_MAJOR,XCHAL_HW_VERSION_MINOR, major,minor ) ? 1 : 0)
+# define XCHAL_HW_RELEASE_MAJOR_AT(major)		((XCHAL_HW_VERSION_MAJOR == (major)) ? 1 : 0)
+#else
+# define XCHAL_HW_RELEASE_AT_OR_BELOW(major,minor)	( ((major) < 1040 && XCHAL_HAVE_XEA2) ? 0 \
+							: ((major) > 1050 && XCHAL_HAVE_XEA1) ? 1 \
+							: XTHAL_MAYBE )
+# define XCHAL_HW_RELEASE_AT_OR_ABOVE(major,minor)	( ((major) >= 2000 && XCHAL_HAVE_XEA1) ? 0 \
+							: (XTHAL_REL_LE(major,minor, 1040,0) && XCHAL_HAVE_XEA2) ? 1 \
+							: XTHAL_MAYBE )
+# define XCHAL_HW_RELEASE_AT(major,minor)		( (((major) < 1040 && XCHAL_HAVE_XEA2) || \
+							   ((major) >= 2000 && XCHAL_HAVE_XEA1)) ? 0 : XTHAL_MAYBE)
+# define XCHAL_HW_RELEASE_MAJOR_AT(major)		XCHAL_HW_RELEASE_AT(major,0)
+#endif
+/*  parasoft-end-suppress MISRA2012-RULE-20_7 "Cannot parenthesize macro args here" */
+
+/*
+ * Erratum present in RH.0 hardware and RH.1 hardware.
+ */
+#if (XCHAL_HW_VERSION == XTENSA_HWVERSION_RH_2016_0) || (XCHAL_HW_VERSION == XTENSA_HWVERSION_RH_2016_1)
+#define XCHAL_RH01_ERRATUM	1
+#else
+#define XCHAL_RH01_ERRATUM	0
+#endif
+
+/*
+ * Erratum present in RH.0 through RH.2 hardware.
+ */
+#if (XCHAL_HW_VERSION == XTENSA_HWVERSION_RH_2016_0) || \
+    (XCHAL_HW_VERSION == XTENSA_HWVERSION_RH_2016_1) || \
+    (XCHAL_HW_VERSION == XTENSA_HWVERSION_RH_2017_2)
+#define XCHAL_RH012_ERRATUM	1
+#else
+#define XCHAL_RH012_ERRATUM	0
+#endif
+
+
+#endif /*XTENSA_CONFIG_CORE_H*/
+

--- a/zephyr/soc/sample_controller32/xtensa/config/defs.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/defs.h
@@ -1,0 +1,37 @@
+/* Definitions for Xtensa instructions, types, and protos. */
+
+/* Copyright (c) 2003-2004 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* NOTE: This file exists only for backward compatibility with T1050
+   and earlier Xtensa releases.  It includes only a subset of the
+   available header files.  */
+
+#ifndef _XTENSA_BASE_HEADER
+#define _XTENSA_BASE_HEADER
+
+#ifdef __XTENSA__
+
+#include <xtensa/tie/xt_core.h>
+#include <xtensa/tie/xt_misc.h>
+
+#endif /* __XTENSA__ */
+#endif /* !_XTENSA_BASE_HEADER */

--- a/zephyr/soc/sample_controller32/xtensa/config/specreg.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/specreg.h
@@ -1,0 +1,104 @@
+/*
+ * Xtensa Special Register symbolic names
+ */
+
+/* $Id: //depot/rel/Homewood/ib.2/Xtensa/SWConfig/hal/specreg.h.tpp#1 $ */
+
+/* Copyright (c) 1998-2002 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef XTENSA_SPECREG_H
+#define XTENSA_SPECREG_H
+
+/*  Include these special register bitfield definitions, for historical reasons:  */
+#include <xtensa/corebits.h>
+
+
+/*  Special registers:  */
+#define SAR		3
+#define WINDOWBASE	72
+#define WINDOWSTART	73
+#define MPUENB		90
+#define IBREAKENABLE	96
+#define MEMCTL		97
+#define CACHEADRDIS	98
+#define DDR		104
+#define IBREAKA_0	128
+#define IBREAKA_1	129
+#define DBREAKA_0	144
+#define DBREAKA_1	145
+#define DBREAKC_0	160
+#define DBREAKC_1	161
+#define EPC_1		177
+#define EPC_2		178
+#define EPC_3		179
+#define EPC_4		180
+#define EPC_5		181
+#define EPC_6		182
+#define EPC_7		183
+#define DEPC		192
+#define EPS_2		194
+#define EPS_3		195
+#define EPS_4		196
+#define EPS_5		197
+#define EPS_6		198
+#define EPS_7		199
+#define EXCSAVE_1	209
+#define EXCSAVE_2	210
+#define EXCSAVE_3	211
+#define EXCSAVE_4	212
+#define EXCSAVE_5	213
+#define EXCSAVE_6	214
+#define EXCSAVE_7	215
+#define INTERRUPT	226
+#define INTENABLE	228
+#define PS		230
+#define VECBASE		231
+#define EXCCAUSE	232
+#define DEBUGCAUSE	233
+#define CCOUNT		234
+#define PRID		235
+#define ICOUNT		236
+#define ICOUNTLEVEL	237
+#define EXCVADDR	238
+#define CCOMPARE_0	240
+#define CCOMPARE_1	241
+#define CCOMPARE_2	242
+#define MISC_REG_0	244
+#define MISC_REG_1	245
+
+
+/*  Special cases (bases of special register series):  */
+#define IBREAKA		128
+#define DBREAKA		144
+#define DBREAKC		160
+#define EPC		176
+#define EPS		192
+#define EXCSAVE		208
+#define CCOMPARE	240
+
+/*  Special names for read-only and write-only interrupt registers:  */
+#define INTREAD		226
+#define INTSET		226
+#define INTCLEAR	227
+
+#endif /* XTENSA_SPECREG_H */
+

--- a/zephyr/soc/sample_controller32/xtensa/config/system.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/system.h
@@ -1,0 +1,262 @@
+/* 
+ * xtensa/config/system.h -- HAL definitions that are dependent on SYSTEM configuration
+ *
+ *  NOTE: The location and contents of this file are highly subject to change.
+ *
+ *  Source for configuration-independent binaries (which link in a
+ *  configuration-specific HAL library) must NEVER include this file.
+ *  The HAL itself has historically included this file in some instances,
+ *  but this is not appropriate either, because the HAL is meant to be
+ *  core-specific but system independent.
+ */
+
+/* Copyright (c) 2000-2010 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+
+#ifndef XTENSA_CONFIG_SYSTEM_H
+#define XTENSA_CONFIG_SYSTEM_H
+
+
+/*----------------------------------------------------------------------
+				CONFIGURED SOFTWARE OPTIONS
+  ----------------------------------------------------------------------*/
+
+#define XSHAL_USE_ABSOLUTE_LITERALS	0	/* (sw-only option, whether software uses absolute literals) */
+#define XSHAL_HAVE_TEXT_SECTION_LITERALS 1 /* Set if there is some memory that allows both code and literals.  */
+
+#define XSHAL_ABI			XTHAL_ABI_WINDOWED	/* (sw-only option, selected ABI) */
+/*  The above maps to one of the following constants:  */
+#define XTHAL_ABI_WINDOWED		0
+#define XTHAL_ABI_CALL0			1
+
+#define XSHAL_CLIB			XTHAL_CLIB_XCLIB	/* (sw-only option, selected C library) */
+/*  The above maps to one of the following constants:  */
+#define XTHAL_CLIB_NEWLIB		0
+#define XTHAL_CLIB_UCLIBC		1
+#define XTHAL_CLIB_XCLIB		2
+
+#define XSHAL_USE_FLOATING_POINT	1
+
+#define XSHAL_FLOATING_POINT_ABI        0
+
+/*  SW workarounds enabled for HW errata:  */
+
+/*----------------------------------------------------------------------
+				DEVICE ADDRESSES
+  ----------------------------------------------------------------------*/
+
+/*
+ *  Strange place to find these, but the configuration GUI
+ *  allows moving these around to account for various core
+ *  configurations.  Specific boards (and their BSP software)
+ *  will have specific meanings for these components.
+ */
+
+/*  I/O Block areas:  */
+#define XSHAL_IOBLOCK_CACHED_VADDR	0x70000000
+#define XSHAL_IOBLOCK_CACHED_PADDR	0x70000000
+#define XSHAL_IOBLOCK_CACHED_SIZE	0x0E000000
+
+#define XSHAL_IOBLOCK_BYPASS_VADDR	0x90000000
+#define XSHAL_IOBLOCK_BYPASS_PADDR	0x90000000
+#define XSHAL_IOBLOCK_BYPASS_SIZE	0x0E000000
+
+/*  System ROM:  */
+#define XSHAL_ROM_VADDR		0x50000000
+#define XSHAL_ROM_PADDR		0x50000000
+#define XSHAL_ROM_SIZE		0x01000000
+/*  Largest available area (free of vectors):  */
+#define XSHAL_ROM_AVAIL_VADDR	0x50000000
+#define XSHAL_ROM_AVAIL_VSIZE	0x01000000
+
+/*  System RAM:  */
+#define XSHAL_RAM_VADDR		0x60000000
+#define XSHAL_RAM_PADDR		0x60000000
+#define XSHAL_RAM_VSIZE		0x04000000
+#define XSHAL_RAM_PSIZE		0x04000000
+#define XSHAL_RAM_SIZE		XSHAL_RAM_PSIZE
+/*  Largest available area (free of vectors):  */
+#define XSHAL_RAM_AVAIL_VADDR	0x60000000
+#define XSHAL_RAM_AVAIL_VSIZE	0x04000000
+
+/*
+ *  Shadow system RAM (same device as system RAM, at different address).
+ *  (Emulation boards need this for the SONIC Ethernet driver
+ *   when data caches are configured for writeback mode.)
+ *  NOTE: on full MMU configs, this points to the BYPASS virtual address
+ *  of system RAM, ie. is the same as XSHAL_RAM_* except that virtual
+ *  addresses are viewed through the BYPASS static map rather than
+ *  the CACHED static map.
+ */
+#define XSHAL_RAM_BYPASS_VADDR		0xA0000000
+#define XSHAL_RAM_BYPASS_PADDR		0xA0000000
+#define XSHAL_RAM_BYPASS_PSIZE		0x04000000
+
+/*  Alternate system RAM (different device than system RAM):  */
+
+/*  Some available location in which to place devices in a simulation (eg. XTMP):  */
+#define XSHAL_SIMIO_CACHED_VADDR	0xC0000000
+#define XSHAL_SIMIO_BYPASS_VADDR	0xC0000000
+#define XSHAL_SIMIO_PADDR		0xC0000000
+#define XSHAL_SIMIO_SIZE		0x20000000
+
+
+/*----------------------------------------------------------------------
+ *  For use by reference testbench exit and diagnostic routines.
+ */
+#define XSHAL_MAGIC_EXIT		0xbf261000
+#define XSHAL_STL_INFO_LOCATION		0x70
+
+/*----------------------------------------------------------------------
+ *			DEVICE-ADDRESS DEPENDENT...
+ *
+ *  Values written to CACHEATTR special register (or its equivalent)
+ *  to enable and disable caches in various modes.
+ *----------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------
+			BACKWARD COMPATIBILITY ...
+  ----------------------------------------------------------------------*/
+
+/*
+ *  NOTE:  the following two macros are DEPRECATED.  Use the latter
+ *  board-specific macros instead, which are specially tuned for the
+ *  particular target environments' memory maps.
+ */
+#define XSHAL_CACHEATTR_BYPASS		XSHAL_XT2000_CACHEATTR_BYPASS	/* disable caches in bypass mode */
+#define XSHAL_CACHEATTR_DEFAULT		XSHAL_XT2000_CACHEATTR_DEFAULT	/* default setting to enable caches (no writeback!) */
+
+/*----------------------------------------------------------------------
+				GENERIC
+  ----------------------------------------------------------------------*/
+
+/*  For the following, a 512MB region is used if it contains a system (PIF) RAM,
+ *  system (PIF) ROM, local memory, or XLMI.  */
+
+/*  These set any unused 512MB region to cache-BYPASS attribute:  */
+#define XSHAL_ALLVALID_CACHEATTR_WRITEBACK	0x22221112	/* enable caches in write-back mode */
+#define XSHAL_ALLVALID_CACHEATTR_WRITEALLOC	0x22221112	/* enable caches in write-allocate mode */
+#define XSHAL_ALLVALID_CACHEATTR_WRITETHRU	0x22221112	/* enable caches in write-through mode */
+#define XSHAL_ALLVALID_CACHEATTR_BYPASS		0x22222222	/* disable caches in bypass mode */
+#define XSHAL_ALLVALID_CACHEATTR_DEFAULT	XSHAL_ALLVALID_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*  These set any unused 512MB region to ILLEGAL attribute:  */
+#define XSHAL_STRICT_CACHEATTR_WRITEBACK	0xFFFF111F	/* enable caches in write-back mode */
+#define XSHAL_STRICT_CACHEATTR_WRITEALLOC	0xFFFF111F	/* enable caches in write-allocate mode */
+#define XSHAL_STRICT_CACHEATTR_WRITETHRU	0xFFFF111F	/* enable caches in write-through mode */
+#define XSHAL_STRICT_CACHEATTR_BYPASS		0xFFFF222F	/* disable caches in bypass mode */
+#define XSHAL_STRICT_CACHEATTR_DEFAULT		XSHAL_STRICT_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*  These set the first 512MB, if unused, to ILLEGAL attribute to help catch
+ *  NULL-pointer dereference bugs; all other unused 512MB regions are set
+ *  to cache-BYPASS attribute:  */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITEBACK	0x2222111F	/* enable caches in write-back mode */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITEALLOC	0x2222111F	/* enable caches in write-allocate mode */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITETHRU	0x2222111F	/* enable caches in write-through mode */
+#define XSHAL_TRAPNULL_CACHEATTR_BYPASS		0x2222222F	/* disable caches in bypass mode */
+#define XSHAL_TRAPNULL_CACHEATTR_DEFAULT	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*----------------------------------------------------------------------
+			ISS (Instruction Set Simulator) SPECIFIC ...
+  ----------------------------------------------------------------------*/
+
+/*  For now, ISS defaults to the TRAPNULL settings:  */
+#define XSHAL_ISS_CACHEATTR_WRITEBACK	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK
+#define XSHAL_ISS_CACHEATTR_WRITEALLOC	XSHAL_TRAPNULL_CACHEATTR_WRITEALLOC
+#define XSHAL_ISS_CACHEATTR_WRITETHRU	XSHAL_TRAPNULL_CACHEATTR_WRITETHRU
+#define XSHAL_ISS_CACHEATTR_BYPASS	XSHAL_TRAPNULL_CACHEATTR_BYPASS
+#define XSHAL_ISS_CACHEATTR_DEFAULT	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK
+
+#define XSHAL_ISS_PIPE_REGIONS	0
+#define XSHAL_ISS_SDRAM_REGIONS	0
+
+
+/*----------------------------------------------------------------------
+			XT2000 BOARD SPECIFIC ...
+  ----------------------------------------------------------------------*/
+
+/*  For the following, a 512MB region is used if it contains any system RAM,
+ *  system ROM, local memory, XLMI, or other XT2000 board device or memory.
+ *  Regions containing devices are forced to cache-BYPASS mode regardless
+ *  of whether the macro is _WRITEBACK vs. _BYPASS etc.  */
+
+/*  These set any 512MB region unused on the XT2000 to ILLEGAL attribute:  */
+#define XSHAL_XT2000_CACHEATTR_WRITEBACK	0xFF22111F	/* enable caches in write-back mode */
+#define XSHAL_XT2000_CACHEATTR_WRITEALLOC	0xFF22111F	/* enable caches in write-allocate mode */
+#define XSHAL_XT2000_CACHEATTR_WRITETHRU	0xFF22111F	/* enable caches in write-through mode */
+#define XSHAL_XT2000_CACHEATTR_BYPASS		0xFF22222F	/* disable caches in bypass mode */
+#define XSHAL_XT2000_CACHEATTR_DEFAULT		XSHAL_XT2000_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+#define XSHAL_XT2000_PIPE_REGIONS	0x00000000	/* BusInt pipeline regions */
+#define XSHAL_XT2000_SDRAM_REGIONS	0x00000440	/* BusInt SDRAM regions */
+
+
+/*----------------------------------------------------------------------
+				VECTOR INFO AND SIZES
+  ----------------------------------------------------------------------*/
+
+#define XSHAL_VECTORS_PACKED		0	/* UNUSED */
+#define XSHAL_STATIC_VECTOR_SELECT	0
+#define XSHAL_RESET_VECTOR_VADDR	0x50000000
+#define XSHAL_RESET_VECTOR_PADDR	0x50000000
+
+/*
+ *  Sizes allocated to vectors by the system (memory map) configuration.
+ *  These sizes are constrained by core configuration (eg. one vector's
+ *  code cannot overflow into another vector) but are dependent on the
+ *  system or board (or LSP) memory map configuration.
+ *
+ *  Whether or not each vector happens to be in a system ROM is also
+ *  a system configuration matter, sometimes useful, included here also:
+ */
+#define XSHAL_RESET_VECTOR_SIZE	0x00000300
+#define XSHAL_RESET_VECTOR_ISROM	1
+#define XSHAL_USER_VECTOR_SIZE	0x00000038
+#define XSHAL_USER_VECTOR_ISROM	0
+#define XSHAL_PROGRAMEXC_VECTOR_SIZE	XSHAL_USER_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_USEREXC_VECTOR_SIZE	XSHAL_USER_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_KERNEL_VECTOR_SIZE	0x00000038
+#define XSHAL_KERNEL_VECTOR_ISROM	0
+#define XSHAL_STACKEDEXC_VECTOR_SIZE	XSHAL_KERNEL_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_KERNELEXC_VECTOR_SIZE	XSHAL_KERNEL_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_DOUBLEEXC_VECTOR_SIZE	0x00000040
+#define XSHAL_DOUBLEEXC_VECTOR_ISROM	0
+#define XSHAL_WINDOW_VECTORS_SIZE	0x00000178
+#define XSHAL_WINDOW_VECTORS_ISROM	0
+#define XSHAL_INTLEVEL2_VECTOR_SIZE	0x00000038
+#define XSHAL_INTLEVEL2_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL3_VECTOR_SIZE	0x00000038
+#define XSHAL_INTLEVEL3_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL4_VECTOR_SIZE	0x00000038
+#define XSHAL_INTLEVEL4_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL5_VECTOR_SIZE	0x00000038
+#define XSHAL_INTLEVEL5_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL6_VECTOR_SIZE	0x00000038
+#define XSHAL_INTLEVEL6_VECTOR_ISROM	0
+#define XSHAL_DEBUG_VECTOR_SIZE		XSHAL_INTLEVEL6_VECTOR_SIZE
+#define XSHAL_DEBUG_VECTOR_ISROM	XSHAL_INTLEVEL6_VECTOR_ISROM
+#define XSHAL_NMI_VECTOR_SIZE	0x00000038
+#define XSHAL_NMI_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL7_VECTOR_SIZE	XSHAL_NMI_VECTOR_SIZE
+
+#endif /*XTENSA_CONFIG_SYSTEM_H*/
+

--- a/zephyr/soc/sample_controller32/xtensa/config/tie-asm.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/tie-asm.h
@@ -1,0 +1,112 @@
+/* 
+ * tie-asm.h -- compile-time HAL assembler definitions dependent on CORE & TIE
+ *
+ *  NOTE:  This header file is not meant to be included directly.
+ */
+
+/* This header file contains assembly-language definitions (assembly
+   macros, etc.) for this specific Xtensa processor's TIE extensions
+   and options.  It is customized to this Xtensa processor configuration.
+
+   Copyright (c) 1999-2019 Cadence Design Systems Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef _XTENSA_CORE_TIE_ASM_H
+#define _XTENSA_CORE_TIE_ASM_H
+
+#include <xtensa/coreasm.h>
+
+/*  Selection parameter values for save-area save/restore macros:  */
+/*  Option vs. TIE:  */
+#define XTHAL_SAS_TIE	0x0001	/* custom extension or coprocessor */
+#define XTHAL_SAS_OPT	0x0002	/* optional (and not a coprocessor) */
+#define XTHAL_SAS_ANYOT	0x0003	/* both of the above */
+/*  Whether used automatically by compiler:  */
+#define XTHAL_SAS_NOCC	0x0004	/* not used by compiler w/o special opts/code */
+#define XTHAL_SAS_CC	0x0008	/* used by compiler without special opts/code */
+#define XTHAL_SAS_ANYCC	0x000C	/* both of the above */
+/*  ABI handling across function calls:  */
+#define XTHAL_SAS_CALR	0x0010	/* caller-saved */
+#define XTHAL_SAS_CALE	0x0020	/* callee-saved */
+#define XTHAL_SAS_GLOB	0x0040	/* global across function calls (in thread) */
+#define XTHAL_SAS_ANYABI	0x0070	/* all of the above three */
+/*  Misc  */
+#define XTHAL_SAS_ALL	0xFFFF	/* include all default NCP contents */
+#define XTHAL_SAS3(optie,ccuse,abi)	( ((optie) & XTHAL_SAS_ANYOT)  \
+					| ((ccuse) & XTHAL_SAS_ANYCC)  \
+					| ((abi)   & XTHAL_SAS_ANYABI) )
+
+
+    /*
+      *  Macro to store all non-coprocessor (extra) custom TIE and optional state
+      *  (not including zero-overhead loop registers).
+      *  Required parameters:
+      *      ptr         Save area pointer address register (clobbered)
+      *                  (register must contain a 1 byte aligned address).
+      *      at1..at4    Four temporary address registers (first XCHAL_NCP_NUM_ATMPS
+      *                  registers are clobbered, the remaining are unused).
+      *  Optional parameters:
+      *      continue    If macro invoked as part of a larger store sequence, set to 1
+      *                  if this is not the first in the sequence.  Defaults to 0.
+      *      ofs         Offset from start of larger sequence (from value of first ptr
+      *                  in sequence) at which to store.  Defaults to next available space
+      *                  (or 0 if <continue> is 0).
+      *      select      Select what category(ies) of registers to store, as a bitmask
+      *                  (see XTHAL_SAS_xxx constants).  Defaults to all registers.
+      *      alloc       Select what category(ies) of registers to allocate; if any
+      *                  category is selected here that is not in <select>, space for
+      *                  the corresponding registers is skipped without doing any store.
+      */
+    .macro xchal_ncp_store  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start	\continue, \ofs
+    .endm	// xchal_ncp_store
+
+    /*
+      *  Macro to load all non-coprocessor (extra) custom TIE and optional state
+      *  (not including zero-overhead loop registers).
+      *  Required parameters:
+      *      ptr         Save area pointer address register (clobbered)
+      *                  (register must contain a 1 byte aligned address).
+      *      at1..at4    Four temporary address registers (first XCHAL_NCP_NUM_ATMPS
+      *                  registers are clobbered, the remaining are unused).
+      *  Optional parameters:
+      *      continue    If macro invoked as part of a larger load sequence, set to 1
+      *                  if this is not the first in the sequence.  Defaults to 0.
+      *      ofs         Offset from start of larger sequence (from value of first ptr
+      *                  in sequence) at which to load.  Defaults to next available space
+      *                  (or 0 if <continue> is 0).
+      *      select      Select what category(ies) of registers to load, as a bitmask
+      *                  (see XTHAL_SAS_xxx constants).  Defaults to all registers.
+      *      alloc       Select what category(ies) of registers to allocate; if any
+      *                  category is selected here that is not in <select>, space for
+      *                  the corresponding registers is skipped without doing any load.
+      */
+    .macro xchal_ncp_load  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start	\continue, \ofs
+    .endm	// xchal_ncp_load
+
+
+#define XCHAL_NCP_NUM_ATMPS	0
+
+#define XCHAL_SA_NUM_ATMPS	0
+
+#endif /*_XTENSA_CORE_TIE_ASM_H*/
+

--- a/zephyr/soc/sample_controller32/xtensa/config/tie.h
+++ b/zephyr/soc/sample_controller32/xtensa/config/tie.h
@@ -1,0 +1,133 @@
+/* 
+ * tie.h -- compile-time HAL definitions dependent on CORE & TIE configuration
+ *
+ *  NOTE:  This header file is not meant to be included directly.
+ */
+
+/* This header file describes this specific Xtensa processor's TIE extensions
+   that extend basic Xtensa core functionality.  It is customized to this
+   Xtensa processor configuration.
+
+   Copyright (c) 1999-2019 Cadence Design Systems Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef XTENSA_CORE_TIE_H
+#define XTENSA_CORE_TIE_H
+
+/* parasoft-begin-suppress ALL "This file not MISRA checked." */
+
+#define XCHAL_CP_NUM			0	/* number of coprocessors */
+#define XCHAL_CP_MAX			0	/* max CP ID + 1 (0 if none) */
+#define XCHAL_CP_MASK			0x00	/* bitmask of all CPs by ID */
+#define XCHAL_CP_PORT_MASK		0x00	/* bitmask of only port CPs */
+
+/*  Save area for non-coprocessor optional and custom (TIE) state:  */
+#define XCHAL_NCP_SA_SIZE		0
+#define XCHAL_NCP_SA_ALIGN		1
+
+/*  Total save area for optional and custom state (NCP + CPn):  */
+#define XCHAL_TOTAL_SA_SIZE		0	/* with 16-byte align padding */
+#define XCHAL_TOTAL_SA_ALIGN		1	/* actual minimum alignment */
+
+/*
+ * Detailed contents of save areas.
+ * NOTE:  caller must define the XCHAL_SA_REG macro (not defined here)
+ * before expanding the XCHAL_xxx_SA_LIST() macros.
+ *
+ * XCHAL_SA_REG(s,ccused,abikind,kind,opt,name,galign,align,asize,
+ *		dbnum,base,regnum,bitsz,gapsz,reset,x...)
+ *
+ *	s = passed from XCHAL_*_LIST(s), eg. to select how to expand
+ *	ccused = set if used by compiler without special options or code
+ *	abikind = 0 (caller-saved), 1 (callee-saved), or 2 (thread-global)
+ *	kind = 0 (special reg), 1 (TIE user reg), or 2 (TIE regfile reg)
+ *	opt = 0 (custom TIE extension or coprocessor), or 1 (optional reg)
+ *	name = lowercase reg name (no quotes)
+ *	galign = group byte alignment (power of 2) (galign >= align)
+ *	align = register byte alignment (power of 2)
+ *	asize = allocated size in bytes (asize*8 == bitsz + gapsz + padsz)
+ *	  (not including any pad bytes required to galign this or next reg)
+ *	dbnum = unique target number f/debug (see <xtensa-libdb-macros.h>)
+ *	base = reg shortname w/o index (or sr=special, ur=TIE user reg)
+ *	regnum = reg index in regfile, or special/TIE-user reg number
+ *	bitsz = number of significant bits (regfile width, or ur/sr mask bits)
+ *	gapsz = intervening bits, if bitsz bits not stored contiguously
+ *	(padsz = pad bits at end [TIE regfile] or at msbits [ur,sr] of asize)
+ *	reset = register reset value (or 0 if undefined at reset)
+ *	x = reserved for future use (0 until then)
+ *
+ *  To filter out certain registers, e.g. to expand only the non-global
+ *  registers used by the compiler, you can do something like this:
+ *
+ *  #define XCHAL_SA_REG(s,ccused,p...)	SELCC##ccused(p)
+ *  #define SELCC0(p...)
+ *  #define SELCC1(abikind,p...)	SELAK##abikind(p)
+ *  #define SELAK0(p...)		REG(p)
+ *  #define SELAK1(p...)		REG(p)
+ *  #define SELAK2(p...)
+ *  #define REG(kind,tie,name,galn,aln,asz,csz,dbnum,base,rnum,bsz,rst,x...) \
+ *		...what you want to expand...
+ */
+
+#define XCHAL_NCP_SA_NUM	0
+#define XCHAL_NCP_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP0_SA_NUM	0
+#define XCHAL_CP0_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP1_SA_NUM	0
+#define XCHAL_CP1_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP2_SA_NUM	0
+#define XCHAL_CP2_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP3_SA_NUM	0
+#define XCHAL_CP3_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP4_SA_NUM	0
+#define XCHAL_CP4_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP5_SA_NUM	0
+#define XCHAL_CP5_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP6_SA_NUM	0
+#define XCHAL_CP6_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP7_SA_NUM	0
+#define XCHAL_CP7_SA_LIST(s)	/* empty */
+
+/* Byte length of instruction from its first nibble (op0 field), per FLIX.  */
+#define XCHAL_OP0_FORMAT_LENGTHS	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3
+/* Byte length of instruction from its first byte, per FLIX.  */
+#define XCHAL_BYTE0_FORMAT_LENGTHS	\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,3,3
+
+/* parasoft-end-suppress ALL "This file not MISRA checked." */
+
+#endif /* XTENSA_CORE_TIE_H */
+


### PR DESCRIPTION
The overlay comes from:

  https://github.com/jcmvbkbc/xtensa-toolchain-build
    commit 435c5e8b108de520565886f3f2349cc6be3fe712
    under directory overlays/

This would allow us to use QEMU to test the Xtensa MPU code on main Zephyr repo.