### PR TITLE
.github: update scancode workflow

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -4,22 +4,31 @@ on: [pull_request]
 
 jobs:
   scancode_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Scan code for licenses
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout the code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Scan the code
       id: scancode
       uses: zephyrproject-rtos/action_scancode@v4
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: scancode
         path: ./artifacts
 
     - name: Verify
       run: |
-        test ! -s ./artifacts/report.txt || (cat ./artifacts/report.txt && exit 1 )
-
+        if [ -s ./artifacts/report.txt ]; then
+          report=$(cat ./artifacts/report.txt)
+          report="${report//'%'/'%25'}"
+          report="${report//$'\n'/'%0A'}"
+          report="${report//$'\r'/'%0D'}"
+          echo "::error file=./artifacts/report.txt::$report"
+          exit 1
+        fi


### PR DESCRIPTION
This updates the scancode (license_check.yml) workflow to reflect what is being used in main Zephyr repo.

The actions/upload-artifact@v1 was too old that GitHub refuses to run the workflow.